### PR TITLE
Replace base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 deps/src/*
 deps/downloads/*
 src/Functions.jl
+deps/build.log
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "Vectorize"
 uuid = "922354f6-6876-5285-8954-7bb8005415d2"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Julia = ">= 0.7"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,8 @@ Julia = ">= 0.7"
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [targets]
-test = ["Test", "Random"]
 build = ["Libdl"]
+test = ["Test", "Random", "SpecialFunctions"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,9 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Julia = ">= 0.7"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Random"]
+build = ["Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Julia = ">= 0.7"
+Julia = "≥0.7"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -12,8 +13,8 @@ Julia = ">= 0.7"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 build = ["Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,6 @@
+name = "Vectorize"
+uuid = "922354f6-6876-5285-8954-7bb8005415d2"
+version = "0.1.0"
+
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/Project.toml
+++ b/Project.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[compat]
+Julia = ">= 0.7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[targets]
+test = ["Test", "Random"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/rprechelt/Vectorize.jl.svg?branch=master)](https://travis-ci.org/rprechelt/Vectorize.jl)
 
 ## Features
-Vectorize.jl provides a unified interface to the high-performance vectorized functions provided by Apple's [Accelerate](https://developer.apple.com/reference/accelerate) framework (OS X only), Intel's [VML](https://software.intel.com/en-us/node/521751) (part of MKL) and [Yeppp!](http://www.yeppp.info/); currently, over 160 functions are supported. These can be accessed using the `Vectorize.LibraryName.Function()` syntax i.e. 
+Vectorize.jl provides a unified interface to the high-performance vectorized functions provided by Apple's [Accelerate](https://developer.apple.com/reference/accelerate) framework (OS X only), Intel's [VML](https://software.intel.com/en-us/node/521751) (part of MKL) and [Yeppp!](http://www.yeppp.info/); currently, over 160 functions are supported. These can be accessed using the `Vectorize.LibraryName.Function()` syntax i.e.
 
     Vectorize.Accelerate.exp(X)
     Vectorize.VML.erf(X)
@@ -17,26 +17,38 @@ Furthermore, a complete benchmarking suite is run during package installation th
 
 will be transparently mapped to the Accelerate, VML or Yeppp! implementation based upon the performance of these frameworks on *your particular machine* and the type of `X`. This mapping happens during package installation and so occurs no runtime overhead (expect to wait a few extra seconds than normal to install this package as the benchmarking suite needs to be run).
 
-Lastly, Vectorize.jl provides a `@vectorize` macro that automatically converts a call to Julia's standard implementation into the fastest vectorized equivalent available on your machine, i.e.
+Vectorize.jl provides a `@vectorize` macro that automatically converts a call to Julia's standard implementation into the fastest vectorized equivalent available on your machine, i.e.
 
     cos(X)    # Standard Julia implementation
     @vectorize cos(X)    # Converted to Yeppp, VML, or Accelerate at compile time
 
-This macro provides an easy method for code to be quickly converted to use Vectorize.jl with little additional effort. 
+This macro provides an easy method for code to be quickly converted to use Vectorize.jl with little additional effort.
 
-The performance benefits are significant; the two plots below the runtime reduction for a small selection of operators available in Vectorize.jl. This data was collected on a 2.5GHz Intel i7 running on OS X; each function was called immediately prior to benchmarking to ensure precompilation, before calculating the average over ten executions using `Vector{Float64}` of length 100. 
+Vectorize.jl also provides a `@replacebase` macro that automatically overloads base broadcasting calls into the fastest vectorized equivalent available.
+
+   X.^(-1/3)  # Standard Julia broadcast implementation
+   Z .= cis.(X)   # Standard Julia in-place broadcast implementation
+   @replacebase cis # Overloads both in-place and out-of-place broadcast calls to cis, provided cis is not fused in the broadcast
+   @replacebase ^ # Note: ^ (pow) is currently only available for VML
+   X.^(-1/3)  # This call now uses Vectorize.pow(X, -1/3)
+   Z .= cis.(X)   # This call now uses Vectorize.cis!
+   @replacebase # This will overload all functions that were benchmarked by Vectorize.jl
+
+This macro allows pre-existing code to take advantage of optimized vectorized implementations with only a line of code. Note that if the broadcast call is multiple function calls fused together, the Vectorize.jl version will not be used, so some care must be taken to write simple broadcasts.
+
+The performance benefits are significant; the two plots below the runtime reduction for a small selection of operators available in Vectorize.jl. This data was collected on a 2.5GHz Intel i7 running on OS X; each function was called immediately prior to benchmarking to ensure precompilation, before calculating the average over ten executions using `Vector{Float64}` of length 100.
 
 ![Accelerate Benchmark](https://raw.githubusercontent.com/rprechelt/Vectorize.jl/master/doc/images/accelerate.png)
 
 ![Vectorize Benchmark](https://raw.githubusercontent.com/rprechelt/Vectorize.jl/master/doc/images/vectorize.png)
 
-These functions can provide orders of magnitude higher-performance than the standard functions in Julia; over 10-fold improvements are common for functions throughout the three libraries. Since these functions are designed to operate on moderate-to-large sized arrays, they tend to be less performant that standard Julia functions for arrays of length less than 10 elements; in that case, it is best not to use Vectorize.jl. 
+These functions can provide orders of magnitude higher-performance than the standard functions in Julia; over 10-fold improvements are common for functions throughout the three libraries. Since these functions are designed to operate on moderate-to-large sized arrays, they tend to be less performant that standard Julia functions for arrays of length less than 10 elements; in that case, it is best not to use Vectorize.jl.
 
 Vectorize.jl will transparently select from the different frameworks that are available on your machine; you are not required to have any particular framework installed (although having all three tends to provide the best performance as different frameworks have different strengths). For users not running OS X, we strongly recommend installing Intel's VML (free for open-source projects under the community license - other licenses are available) as the only other library available for non-OSX systems is Yeppp, and Yeppp only provides a very small collection of functions.
 
-This package currently supports over 40 functions over `Float32`, `Float64`, `Complex{Float32}`, and `Complex{Float64}`; `Vectorize.Yeppp` also provides access to various Yeppp functions over `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Int8`, `Int16`, `Int32`, and `Int64` (although these are not benchmarked as neither Accelerate or VML provide equivalent functions). Every function provided by VML is currently supported, alongside the vast majority of optimized Yeppp functions and an equivalent portion of Accelerate. Please see the documentation for a complete list of provided functions and implementations. 
+This package currently supports over 40 functions over `Float32`, `Float64`, `Complex{Float32}`, and `Complex{Float64}`; `Vectorize.Yeppp` also provides access to various Yeppp functions over `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Int8`, `Int16`, `Int32`, and `Int64` (although these are not benchmarked as neither Accelerate or VML provide equivalent functions). Every function provided by VML is currently supported, alongside the vast majority of optimized Yeppp functions and an equivalent portion of Accelerate. Please see the documentation for a complete list of provided functions and implementations.
 
-## Installation 
+## Installation
 To install the latest version of Vectorize from `master`, run
 
     Pkg.clone("http://github.com/rprechelt/Vectorize.jl")
@@ -49,6 +61,6 @@ Once the package has finished cloning, run
 
     Pkg.build("Vectorize")
 
-This will print the build status to the terminal; you will be notified if the build completes successfully. This will attempt to determine which frameworks are available on your machine and incorporate those frameworks into the benchmarking process; if it is unable to locate Yeppp!, it will download a local copy and store it in the Vectorize.jl package directory (no changes are made to your system by installing Vectorize.jl). The build process will report what frameworks it is able to find - if it unable to find your system-installed version of Yeppp! or MKL, please ensure that they are both in your system PATH. 
+This will print the build status to the terminal; you will be notified if the build completes successfully. This will attempt to determine which frameworks are available on your machine and incorporate those frameworks into the benchmarking process; if it is unable to locate Yeppp!, it will download a local copy and store it in the Vectorize.jl package directory (no changes are made to your system by installing Vectorize.jl). The build process will report what frameworks it is able to find - if it unable to find your system-installed version of Yeppp! or MKL, please ensure that they are both in your system PATH.
 
-If the build fails, or it is unable to find system-installed packages correctly, please create an issue on Github and copy the output of `Pkg.build()` into the issue. This will help in debugging the build failures. 
+If the build fails, or it is unable to find system-installed packages correctly, please create an issue on Github and copy the output of `Pkg.build()` into the issue. This will help in debugging the build failures.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,11 +14,7 @@ include("clean.jl")
 # compute package directory location
 currdir = @__FILE__
 pkgdir = currdir[1:end-13]
-@static if is_windows()
-    function_location = pkgdir*"src\Functions.jl"
-else
-    function_location = pkgdir*"src/Functions.jl"
-end
+function_location = joinpath(pkgdir*"src", "Functions.jl")
 
 # detect architecture
 if Sys.ARCH != :x86_64
@@ -26,32 +22,20 @@ if Sys.ARCH != :x86_64
     exit(1)
 end
 
-@static if is_windows()
-    include("windows.jl")
-else
-    include("unix.jl")
-end
+@static Sys.iswindows() ? include("windows.jl") : include("unix.jl")
 
 # Have to import vectorize after Yeppp is downloaded
-@static if is_windows()
-    push!(LOAD_PATH, parsedir("$(pkgdir)src\\"))
-else
-    push!(LOAD_PATH, parsedir("$(pkgdir)src/"))
-end
+push!(LOAD_PATH, "$(pkgdir)src")
 
 # import vectorize in order to benchmark
 using Vectorize
 
 # available functions - Yeppp, VML, Accelerate register against this dictionary
-functions = Vectorize.functions 
+functions = Vectorize.functions
 
 # Run the benchmarking process
 N = 1_000 # length of each vector
-@static if is_windows()
-    file = open("$(pkgdir)src\Functions.jl", "a")
-else
-    file = open("$(pkgdir)src/Functions.jl", "a")
-end
+file = open(joinpath("$(pkgdir)src", "Functions.jl"), "a")
 
 for ((f, T), options) in functions
     if length(T) == 1
@@ -64,4 +48,4 @@ for ((f, T), options) in functions
 end
 close(file)
 
-Base.compilecache("Vectorize")
+Base.compilecache(Base.PkgId(Base.UUID("922354f6-6876-5285-8954-7bb8005415d2"), "Vectorize"))

--- a/deps/build.log
+++ b/deps/build.log
@@ -1,0 +1,480 @@
+TESTING: acosh(Array{Float32})
+BENCHMARK: acosh(Array{Float32}) mapped to Vectorize.Accelerate.acosh()
+
+TESTING: sub!(Array{Float64}, Array{Float64}, Array{Float64})
+BENCHMARK: sub!(Array{Float64}, Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.sub!()
+
+TESTING: atanh(Array{Float32})
+BENCHMARK: atanh(Array{Float32}) mapped to Vectorize.Accelerate.atanh()
+
+TESTING: round(Array{Float32})
+BENCHMARK: round(Array{Float32}) mapped to Vectorize.Accelerate.round()
+
+TESTING: sinpi(Array{Float32})
+BENCHMARK: sinpi(Array{Float32}) mapped to Vectorize.Accelerate.sinpi()
+
+TESTING: acos!(Array{Float32}, Array{Float32})
+BENCHMARK: acos!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.acos!()
+
+TESTING: log(Array{Float32})
+BENCHMARK: log(Array{Float32}) mapped to Vectorize.Accelerate.log()
+
+TESTING: log!(Array{Float32}, Array{Float32})
+BENCHMARK: log!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.log!()
+
+TESTING: log2!(Array{Float32}, Array{Float32})
+BENCHMARK: log2!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.log2!()
+
+TESTING: sub(Array{Float64}, Array{Float64})
+BENCHMARK: sub(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.sub()
+
+TESTING: expm1(Array{Float64})
+BENCHMARK: expm1(Array{Float64}) mapped to Vectorize.Accelerate.expm1()
+
+TESTING: mul(Array{Float64}, Array{Float64})
+BENCHMARK: mul(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.mul()
+
+TESTING: atan!(Array{Float64}, Array{Float64})
+BENCHMARK: atan!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.atan!()
+
+TESTING: sqrt!(Array{Float64}, Array{Float64})
+BENCHMARK: sqrt!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.sqrt!()
+
+TESTING: exp!(Array{Float64}, Array{Float64})
+BENCHMARK: exp!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.exp!()
+
+TESTING: max!(Array{Float32}, Array{Float32}, Array{Float32})
+BENCHMARK: max!(Array{Float32}, Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.max!()
+
+TESTING: log2(Array{Float64})
+BENCHMARK: log2(Array{Float64}) mapped to Vectorize.Accelerate.log2()
+
+TESTING: abs!(Array{Float64}, Array{Float64})
+BENCHMARK: abs!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.abs!()
+
+TESTING: sinpi!(Array{Float32}, Array{Float32})
+BENCHMARK: sinpi!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.sinpi!()
+
+TESTING: asin!(Array{Float64}, Array{Float64})
+BENCHMARK: asin!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.asin!()
+
+TESTING: rec(Array{Float64})
+BENCHMARK: rec(Array{Float64}) mapped to Vectorize.Accelerate.rec()
+
+TESTING: sqrt(Array{Float64})
+BENCHMARK: sqrt(Array{Float64}) mapped to Vectorize.Accelerate.sqrt()
+
+TESTING: div(Array{Float64}, Array{Float64})
+BENCHMARK: div(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.div()
+
+TESTING: log2(Array{Float32})
+BENCHMARK: log2(Array{Float32}) mapped to Vectorize.Accelerate.log2()
+
+TESTING: asinh(Array{Float32})
+BENCHMARK: asinh(Array{Float32}) mapped to Vectorize.Accelerate.asinh()
+
+TESTING: tanpi!(Array{Float64}, Array{Float64})
+BENCHMARK: tanpi!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.tanpi!()
+
+TESTING: floor(Array{Float32})
+BENCHMARK: floor(Array{Float32}) mapped to Vectorize.Accelerate.floor()
+
+TESTING: exp2(Array{Float64})
+BENCHMARK: exp2(Array{Float64}) mapped to Vectorize.Accelerate.exp2()
+
+TESTING: expm1(Array{Float32})
+BENCHMARK: expm1(Array{Float32}) mapped to Vectorize.Accelerate.expm1()
+
+TESTING: cosh(Array{Float32})
+BENCHMARK: cosh(Array{Float32}) mapped to Vectorize.Accelerate.cosh()
+
+TESTING: sub(Array{Float32}, Array{Float32})
+BENCHMARK: sub(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.sub()
+
+TESTING: asin(Array{Float64})
+BENCHMARK: asin(Array{Float64}) mapped to Vectorize.Accelerate.asin()
+
+TESTING: rec!(Array{Float64}, Array{Float64})
+BENCHMARK: rec!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.rec!()
+
+TESTING: log1p(Array{Float32})
+BENCHMARK: log1p(Array{Float32}) mapped to Vectorize.Accelerate.log1p()
+
+TESTING: floor(Array{Float64})
+BENCHMARK: floor(Array{Float64}) mapped to Vectorize.Accelerate.floor()
+
+TESTING: invsqrt!(Array{Float32}, Array{Float32})
+BENCHMARK: invsqrt!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.invsqrt!()
+
+TESTING: min!(Array{Float64}, Array{Float64}, Array{Float64})
+BENCHMARK: min!(Array{Float64}, Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.min!()
+
+TESTING: min(Array{Float64}, Array{Float64})
+BENCHMARK: min(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.min()
+
+TESTING: div!(Array{Float64}, Array{Float64}, Array{Float64})
+BENCHMARK: div!(Array{Float64}, Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.div!()
+
+TESTING: cos(Array{Float64})
+BENCHMARK: cos(Array{Float64}) mapped to Vectorize.Accelerate.cos()
+
+TESTING: cospi(Array{Float32})
+BENCHMARK: cospi(Array{Float32}) mapped to Vectorize.Accelerate.cospi()
+
+TESTING: round!(Array{Float32}, Array{Float32})
+BENCHMARK: round!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.round!()
+
+TESTING: mean(Array{Float64})
+BENCHMARK: mean(Array{Float64}) mapped to Vectorize.Accelerate.mean()
+
+TESTING: rec!(Array{Float32}, Array{Float32})
+BENCHMARK: rec!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.rec!()
+
+TESTING: sqrt!(Array{Float32}, Array{Float32})
+BENCHMARK: sqrt!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.sqrt!()
+
+TESTING: summag(Array{Float32})
+BENCHMARK: summag(Array{Float32}) mapped to Vectorize.Accelerate.summag()
+
+TESTING: add(Array{Float32}, Array{Float32})
+BENCHMARK: add(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.add()
+
+TESTING: sum(Array{Float64})
+BENCHMARK: sum(Array{Float64}) mapped to Vectorize.Accelerate.sum()
+
+TESTING: exp!(Array{Float32}, Array{Float32})
+BENCHMARK: exp!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.exp!()
+
+TESTING: ceil(Array{Float64})
+BENCHMARK: ceil(Array{Float64}) mapped to Vectorize.Accelerate.ceil()
+
+TESTING: ceil!(Array{Float64}, Array{Float64})
+BENCHMARK: ceil!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.ceil!()
+
+TESTING: trunc!(Array{Float64}, Array{Float64})
+BENCHMARK: trunc!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.trunc!()
+
+TESTING: ceil(Array{Float32})
+BENCHMARK: ceil(Array{Float32}) mapped to Vectorize.Accelerate.ceil()
+
+TESTING: asinh!(Array{Float32}, Array{Float32})
+BENCHMARK: asinh!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.asinh!()
+
+TESTING: exponent(Array{Float32})
+BENCHMARK: exponent(Array{Float32}) mapped to Vectorize.Accelerate.exponent()
+
+TESTING: cosh!(Array{Float64}, Array{Float64})
+BENCHMARK: cosh!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.cosh!()
+
+TESTING: asinh(Array{Float64})
+BENCHMARK: asinh(Array{Float64}) mapped to Vectorize.Accelerate.asinh()
+
+TESTING: abs!(Array{Float32}, Array{Float32})
+BENCHMARK: abs!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.abs!()
+
+TESTING: exponent!(Array{Float32}, Array{Float32})
+BENCHMARK: exponent!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.exponent!()
+
+TESTING: log1p!(Array{Float32}, Array{Float32})
+BENCHMARK: log1p!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.log1p!()
+
+TESTING: acos!(Array{Float64}, Array{Float64})
+BENCHMARK: acos!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.acos!()
+
+TESTING: cospi!(Array{Float32}, Array{Float32})
+BENCHMARK: cospi!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.cospi!()
+
+TESTING: cospi(Array{Float64})
+BENCHMARK: cospi(Array{Float64}) mapped to Vectorize.Accelerate.cospi()
+
+TESTING: add!(Array{Float32}, Array{Float32}, Array{Float32})
+BENCHMARK: add!(Array{Float32}, Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.add!()
+
+TESTING: exp2(Array{Float32})
+BENCHMARK: exp2(Array{Float32}) mapped to Vectorize.Accelerate.exp2()
+
+TESTING: acos(Array{Float64})
+BENCHMARK: acos(Array{Float64}) mapped to Vectorize.Accelerate.acos()
+
+TESTING: asin!(Array{Float32}, Array{Float32})
+BENCHMARK: asin!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.asin!()
+
+TESTING: log10(Array{Float32})
+BENCHMARK: log10(Array{Float32}) mapped to Vectorize.Accelerate.log10()
+
+TESTING: sum(Array{Float32})
+BENCHMARK: sum(Array{Float32}) mapped to Vectorize.Accelerate.sum()
+
+TESTING: minimum(Array{Float32})
+BENCHMARK: minimum(Array{Float32}) mapped to Vectorize.Accelerate.minimum()
+
+TESTING: log10!(Array{Float32}, Array{Float32})
+BENCHMARK: log10!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.log10!()
+
+TESTING: trunc(Array{Float32})
+BENCHMARK: trunc(Array{Float32}) mapped to Vectorize.Accelerate.trunc()
+
+TESTING: log!(Array{Float64}, Array{Float64})
+BENCHMARK: log!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.log!()
+
+TESTING: invsqrt(Array{Float32})
+BENCHMARK: invsqrt(Array{Float32}) mapped to Vectorize.Accelerate.invsqrt()
+
+TESTING: atan(Array{Float64})
+BENCHMARK: atan(Array{Float64}) mapped to Vectorize.Accelerate.atan()
+
+TESTING: sinh!(Array{Float32}, Array{Float32})
+BENCHMARK: sinh!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.sinh!()
+
+TESTING: sqrt(Array{Float32})
+BENCHMARK: sqrt(Array{Float32}) mapped to Vectorize.Accelerate.sqrt()
+
+TESTING: tanpi!(Array{Float32}, Array{Float32})
+BENCHMARK: tanpi!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.tanpi!()
+
+TESTING: abs(Array{Float64})
+BENCHMARK: abs(Array{Float64}) mapped to Vectorize.Accelerate.abs()
+
+TESTING: atan!(Array{Float32}, Array{Float32})
+BENCHMARK: atan!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.atan!()
+
+TESTING: invsqrt!(Array{Float64}, Array{Float64})
+BENCHMARK: invsqrt!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.invsqrt!()
+
+TESTING: log10!(Array{Float64}, Array{Float64})
+BENCHMARK: log10!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.log10!()
+
+TESTING: atanh!(Array{Float64}, Array{Float64})
+BENCHMARK: atanh!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.atanh!()
+
+TESTING: atanh(Array{Float64})
+BENCHMARK: atanh(Array{Float64}) mapped to Vectorize.Accelerate.atanh()
+
+TESTING: sinpi(Array{Float64})
+BENCHMARK: sinpi(Array{Float64}) mapped to Vectorize.Accelerate.sinpi()
+
+TESTING: cospi!(Array{Float64}, Array{Float64})
+BENCHMARK: cospi!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.cospi!()
+
+TESTING: tan!(Array{Float64}, Array{Float64})
+BENCHMARK: tan!(Array{Float64}, Array{Float64}) mapped to Vectorize.Yeppp.tan!()
+
+TESTING: rec(Array{Float32})
+BENCHMARK: rec(Array{Float32}) mapped to Vectorize.Accelerate.rec()
+
+TESTING: log(Array{Float64})
+BENCHMARK: log(Array{Float64}) mapped to Vectorize.Accelerate.log()
+
+TESTING: sin(Array{Float32})
+BENCHMARK: sin(Array{Float32}) mapped to Vectorize.Accelerate.sin()
+
+TESTING: asin(Array{Float32})
+BENCHMARK: asin(Array{Float32}) mapped to Vectorize.Accelerate.asin()
+
+TESTING: div!(Array{Float32}, Array{Float32}, Array{Float32})
+BENCHMARK: div!(Array{Float32}, Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.div!()
+
+TESTING: exp2!(Array{Float32}, Array{Float32})
+BENCHMARK: exp2!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.exp2!()
+
+TESTING: round!(Array{Float64}, Array{Float64})
+BENCHMARK: round!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.round!()
+
+TESTING: tanh!(Array{Float64}, Array{Float64})
+BENCHMARK: tanh!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.tanh!()
+
+TESTING: max(Array{Float32}, Array{Float32})
+BENCHMARK: max(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.max()
+
+TESTING: mul!(Array{Float32}, Array{Float32}, Array{Float32})
+BENCHMARK: mul!(Array{Float32}, Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.mul!()
+
+TESTING: sub!(Array{Float32}, Array{Float32}, Array{Float32})
+BENCHMARK: sub!(Array{Float32}, Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.sub!()
+
+TESTING: tan!(Array{Float32}, Array{Float32})
+BENCHMARK: tan!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.tan!()
+
+TESTING: sin!(Array{Float32}, Array{Float32})
+BENCHMARK: sin!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.sin!()
+
+TESTING: sumsqr(Array{Float32})
+BENCHMARK: sumsqr(Array{Float32}) mapped to Vectorize.Accelerate.sumsqr()
+
+TESTING: asinh!(Array{Float64}, Array{Float64})
+BENCHMARK: asinh!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.asinh!()
+
+TESTING: atanh!(Array{Float32}, Array{Float32})
+BENCHMARK: atanh!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.atanh!()
+
+TESTING: ceil!(Array{Float32}, Array{Float32})
+BENCHMARK: ceil!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.ceil!()
+
+TESTING: cos!(Array{Float32}, Array{Float32})
+BENCHMARK: cos!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.cos!()
+
+TESTING: mul(Array{Float32}, Array{Float32})
+BENCHMARK: mul(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.mul()
+
+TESTING: expm1!(Array{Float32}, Array{Float32})
+BENCHMARK: expm1!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.expm1!()
+
+TESTING: add(Array{Float64}, Array{Float64})
+BENCHMARK: add(Array{Float64}, Array{Float64}) mapped to Vectorize.Yeppp.add()
+
+TESTING: summag(Array{Float64})
+BENCHMARK: summag(Array{Float64}) mapped to Vectorize.Accelerate.summag()
+
+TESTING: sinpi!(Array{Float64}, Array{Float64})
+BENCHMARK: sinpi!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.sinpi!()
+
+TESTING: abs(Array{Float32})
+BENCHMARK: abs(Array{Float32}) mapped to Vectorize.Accelerate.abs()
+
+TESTING: log1p!(Array{Float64}, Array{Float64})
+BENCHMARK: log1p!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.log1p!()
+
+TESTING: cos(Array{Float32})
+BENCHMARK: cos(Array{Float32}) mapped to Vectorize.Accelerate.cos()
+
+TESTING: mean(Array{Float32})
+BENCHMARK: mean(Array{Float32}) mapped to Vectorize.Accelerate.mean()
+
+TESTING: cosh!(Array{Float32}, Array{Float32})
+BENCHMARK: cosh!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.cosh!()
+
+TESTING: sin(Array{Float64})
+BENCHMARK: sin(Array{Float64}) mapped to Vectorize.Accelerate.sin()
+
+TESTING: tan(Array{Float64})
+BENCHMARK: tan(Array{Float64}) mapped to Vectorize.Yeppp.tan()
+
+TESTING: max!(Array{Float64}, Array{Float64}, Array{Float64})
+BENCHMARK: max!(Array{Float64}, Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.max!()
+
+TESTING: trunc(Array{Float64})
+BENCHMARK: trunc(Array{Float64}) mapped to Vectorize.Accelerate.trunc()
+
+TESTING: tanh(Array{Float32})
+BENCHMARK: tanh(Array{Float32}) mapped to Vectorize.Accelerate.tanh()
+
+TESTING: tanpi(Array{Float32})
+BENCHMARK: tanpi(Array{Float32}) mapped to Vectorize.Accelerate.tanpi()
+
+TESTING: div(Array{Float32}, Array{Float32})
+BENCHMARK: div(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.div()
+
+TESTING: sumsqr(Array{Float64})
+BENCHMARK: sumsqr(Array{Float64}) mapped to Vectorize.Accelerate.sumsqr()
+
+TESTING: minimum(Array{Float64})
+BENCHMARK: minimum(Array{Float64}) mapped to Vectorize.Accelerate.minimum()
+
+TESTING: cosh(Array{Float64})
+BENCHMARK: cosh(Array{Float64}) mapped to Vectorize.Accelerate.cosh()
+
+TESTING: max(Array{Float64}, Array{Float64})
+BENCHMARK: max(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.max()
+
+TESTING: sinh(Array{Float32})
+BENCHMARK: sinh(Array{Float32}) mapped to Vectorize.Accelerate.sinh()
+
+TESTING: maximum(Array{Float64})
+BENCHMARK: maximum(Array{Float64}) mapped to Vectorize.Accelerate.maximum()
+
+TESTING: exponent!(Array{Float64}, Array{Float64})
+BENCHMARK: exponent!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.exponent!()
+
+TESTING: exp2!(Array{Float64}, Array{Float64})
+BENCHMARK: exp2!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.exp2!()
+
+TESTING: invsqrt(Array{Float64})
+BENCHMARK: invsqrt(Array{Float64}) mapped to Vectorize.Accelerate.invsqrt()
+
+TESTING: acos(Array{Float32})
+BENCHMARK: acos(Array{Float32}) mapped to Vectorize.Accelerate.acos()
+
+TESTING: mul!(Array{Float64}, Array{Float64}, Array{Float64})
+BENCHMARK: mul!(Array{Float64}, Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.mul!()
+
+TESTING: exp(Array{Float32})
+BENCHMARK: exp(Array{Float32}) mapped to Vectorize.Accelerate.exp()
+
+TESTING: add!(Array{Float64}, Array{Float64}, Array{Float64})
+BENCHMARK: add!(Array{Float64}, Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.add!()
+
+TESTING: log1p(Array{Float64})
+BENCHMARK: log1p(Array{Float64}) mapped to Vectorize.Accelerate.log1p()
+
+TESTING: acosh!(Array{Float64}, Array{Float64})
+BENCHMARK: acosh!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.acosh!()
+
+TESTING: log2!(Array{Float64}, Array{Float64})
+BENCHMARK: log2!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.log2!()
+
+TESTING: sinh(Array{Float64})
+BENCHMARK: sinh(Array{Float64}) mapped to Vectorize.Accelerate.sinh()
+
+TESTING: acosh(Array{Float64})
+BENCHMARK: acosh(Array{Float64}) mapped to Vectorize.Accelerate.acosh()
+
+TESTING: sin!(Array{Float64}, Array{Float64})
+BENCHMARK: sin!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.sin!()
+
+TESTING: exp(Array{Float64})
+BENCHMARK: exp(Array{Float64}) mapped to Vectorize.Accelerate.exp()
+
+TESTING: exponent(Array{Float64})
+BENCHMARK: exponent(Array{Float64}) mapped to Vectorize.Accelerate.exponent()
+
+TESTING: maximum(Array{Float32})
+BENCHMARK: maximum(Array{Float32}) mapped to Vectorize.Accelerate.maximum()
+
+TESTING: min!(Array{Float32}, Array{Float32}, Array{Float32})
+BENCHMARK: min!(Array{Float32}, Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.min!()
+
+TESTING: tanh!(Array{Float32}, Array{Float32})
+BENCHMARK: tanh!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.tanh!()
+
+TESTING: log10(Array{Float64})
+BENCHMARK: log10(Array{Float64}) mapped to Vectorize.Accelerate.log10()
+
+TESTING: floor!(Array{Float64}, Array{Float64})
+BENCHMARK: floor!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.floor!()
+
+TESTING: expm1!(Array{Float64}, Array{Float64})
+BENCHMARK: expm1!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.expm1!()
+
+TESTING: tanh(Array{Float64})
+BENCHMARK: tanh(Array{Float64}) mapped to Vectorize.Accelerate.tanh()
+
+TESTING: acosh!(Array{Float32}, Array{Float32})
+BENCHMARK: acosh!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.acosh!()
+
+TESTING: round(Array{Float64})
+BENCHMARK: round(Array{Float64}) mapped to Vectorize.Accelerate.round()
+
+TESTING: cos!(Array{Float64}, Array{Float64})
+BENCHMARK: cos!(Array{Float64}, Array{Float64}) mapped to Vectorize.Yeppp.cos!()
+
+TESTING: min(Array{Float32}, Array{Float32})
+BENCHMARK: min(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.min()
+
+TESTING: tanpi(Array{Float64})
+BENCHMARK: tanpi(Array{Float64}) mapped to Vectorize.Accelerate.tanpi()
+
+TESTING: atan(Array{Float32})
+BENCHMARK: atan(Array{Float32}) mapped to Vectorize.Accelerate.atan()
+
+TESTING: floor!(Array{Float32}, Array{Float32})
+BENCHMARK: floor!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.floor!()
+
+TESTING: tan(Array{Float32})
+BENCHMARK: tan(Array{Float32}) mapped to Vectorize.Accelerate.tan()
+
+TESTING: sinh!(Array{Float64}, Array{Float64})
+BENCHMARK: sinh!(Array{Float64}, Array{Float64}) mapped to Vectorize.Accelerate.sinh!()
+
+TESTING: trunc!(Array{Float32}, Array{Float32})
+BENCHMARK: trunc!(Array{Float32}, Array{Float32}) mapped to Vectorize.Accelerate.trunc!()
+

--- a/deps/clean.jl
+++ b/deps/clean.jl
@@ -13,7 +13,7 @@ currdir = @__FILE__
 pkgdir = currdir[1:end-13]
 
 # Clean up directory status
-@static if is_windows()
+@static if Sys.iswindows()
     run(`cmd /C del $(pkgdir)src\\Functions.jl`)
     run(`cmd /C copy NUL Functions.jl`)
     run(`cmd /C move Functions.jl $(pkgdir)src`)

--- a/deps/helper.jl
+++ b/deps/helper.jl
@@ -1,26 +1,8 @@
-# Cross-version compatibility
-if VERSION < v"0.5.0-dev" # Julia v0.4
-    readstring(cmd) = readall(cmd)
-end
-
-"""
-This function handles automatic conversion of OS X/Linux directories
-by converting / into \ on Windows platfors. 
-"""
-@inline function parsedir(dirname)
-    @static if is_windows()
-        return replace(dirname, "/", "\\")
-    else
-        return dirname
-    end
-end
-
-
 """
 This function selects a single implementation from `fnames` and associates it
 with `fname`. It benchmarks every function in `fnames` against the single
-type `Vector{T}` of length `N` and writes the resulting association into the 
-IOstream `file`.  
+type `Vector{T}` of length `N` and writes the resulting association into the
+IOstream `file`.
 
     fname: name to be associated with Vectorize.(fname)
     fnames: a list of strings "Vectorize.VML.sin" to be benchmarked
@@ -30,15 +12,15 @@ IOstream `file`.
 """
 function benchmarkSingleArgFunction(fname, fnames,
                                     T::DataType, file::IOStream, N::Integer)
-    
+
     # dictionary to store elpased values
     val = Dict()
     println("TESTING: $(fname)(Array{$T})")
-    
+
     # Iterate over all functions
     for fstr in fnames
-        f = eval(parse(fstr)) # convert string to function
-        X = convert(Array{T}, randn(N)) # function arguments
+        f = eval(Meta.parse(fstr)) # convert string to function
+        X = randn(T, N) # function arguments
         f(X) # force compilation
         time = 0
         for i in 1:10 # benchmark ten times
@@ -71,8 +53,8 @@ end
 """
 This function selects a single implementation from `fnames` and associates it
 with `fname`. It benchmarks every function in `fnames` against two `Vector{T}`'s
-of length `N` and writes the resulting association into the 
-IOstream `file`. 
+of length `N` and writes the resulting association into the
+IOstream `file`.
 
     fname: name to be associated with Vectorize.(fname)
     fnames: a list of strings "Vectorize.VML.sin" to be benchmarked
@@ -82,16 +64,16 @@ IOstream `file`.
 """
 function benchmarkTwoArgFunction(fname, fnames,
                                  T::Tuple{DataType, DataType}, file::IOStream, N::Integer)
-    
+
     # dictionary of elapsed times for each implementation
     val = Dict()
     println("TESTING: $(fname)(Array{$(T[1])}, Array{$(T[2])})")
-    
+
     # Iterate over all functions
     for fstr in fnames
-        f = eval(parse(fstr)) # convert string to function
-        X = convert(Vector{T[1]}, randn(N)) # function arguments
-        Y = convert(Vector{T[2]}, randn(N)) # function arguments
+        f = eval(Meta.parse(fstr)) # convert string to function
+        X = randn(T[1], N) # function arguments
+        Y = randn(T[2], N) # function arguments
         f(X, Y) # force compilation
         time = 0
         for i in 1:10 # benchmark ten times
@@ -121,8 +103,8 @@ end
 """
 This function selects a single implementation from `fnames` and associates it
 with `fname`. It benchmarks every function in `fnames` against three `Array{T}`'s
-of length `N` and writes the resulting association into the 
-IOstream `file`. 
+of length `N` and writes the resulting association into the
+IOstream `file`.
 
     fname: name to be associated with Vectorize.(fname)
     fnames: a list of strings "Vectorize.VML.sin" to be benchmarked
@@ -132,17 +114,17 @@ IOstream `file`.
 """
 function benchmarkThreeArgFunction(fname, fnames,
                                    T::Tuple{DataType, DataType, DataType}, file::IOStream, N::Integer)
-    
+
     # dictionary to store elapsed values
     val = Dict()
     println("TESTING: $(fname)(Array{$(T[1])}, Array{$(T[2])}, Array{$(T[3])})")
-    
+
     # Iterate over all functions
     for fstr in fnames
-        f = eval(parse(fstr)) # convert string to function
-        X = convert(Array{T[1]}, randn(N)) # function arguments
-        Y = convert(Array{T[2]}, randn(N)) # function arguments
-        Z = convert(Array{T[3]}, randn(N)) # function arguments
+        f = eval(Meta.parse(fstr)) # convert string to function
+        X = randn(T[1], N) # function arguments
+        Y = randn(T[2], N) # function arguments
+        Z = randn(T[3], N) # function arguments
         f(X, Y, Z) # force compilation
         time = 0
         for i in 1:10 # benchmark 10 times

--- a/deps/helper.jl
+++ b/deps/helper.jl
@@ -11,7 +11,7 @@ IOstream `file`.
     N: the length of the vector to benchmark over.
 """
 function benchmarkSingleArgFunction(fname, fnames,
-                                    T::DataType, file::IOStream, N::Integer)
+                                    T, file::IOStream, N::Integer)
 
     # dictionary to store elpased values
     val = Dict()
@@ -20,7 +20,7 @@ function benchmarkSingleArgFunction(fname, fnames,
     # Iterate over all functions
     for fstr in fnames
         f = eval(Meta.parse(fstr)) # convert string to function
-        X = randn(T, N) # function arguments
+        X = randn(eltype(T), N) # function arguments
         f(X) # force compilation
         time = 0
         for i in 1:10 # benchmark ten times
@@ -42,11 +42,11 @@ function benchmarkSingleArgFunction(fname, fnames,
     end
 
     # write chosen file into IOStream
-    write(file, "\n$(fname)(X::Array{$T}) = $(fbest)(X)\n")
+    write(file, "\n$(fname)(X::$T) = $(fbest)(X)\n")
     # docs = @doc fbest
     # write(file, "\n\"\"\"\n", docs, "\n\"\"\"\n")
     # write(file, "$(fname)(X::Array{$T}) = $(fbest)(X)\n")
-    println("BENCHMARK: $(fname)(Array{$T}) mapped to $(fbest)()\n")
+    println("BENCHMARK: $(fname)($T) mapped to $(fbest)()\n")
 end
 
 
@@ -63,17 +63,17 @@ IOstream `file`.
     N: the length of the vector to benchmark over.
 """
 function benchmarkTwoArgFunction(fname, fnames,
-                                 T::Tuple{DataType, DataType}, file::IOStream, N::Integer)
+                                 T, file::IOStream, N::Integer)
 
     # dictionary of elapsed times for each implementation
     val = Dict()
-    println("TESTING: $(fname)(Array{$(T[1])}, Array{$(T[2])})")
+    println("TESTING: $(fname)($(T[1]), $(T[2]))")
 
     # Iterate over all functions
     for fstr in fnames
         f = eval(Meta.parse(fstr)) # convert string to function
-        X = randn(T[1], N) # function arguments
-        Y = randn(T[2], N) # function arguments
+        X = randn(eltype(T[1]), N) # function arguments
+        Y = randn(eltype(T[2]), N) # function arguments
         f(X, Y) # force compilation
         time = 0
         for i in 1:10 # benchmark ten times
@@ -95,8 +95,8 @@ function benchmarkTwoArgFunction(fname, fnames,
     end
 
     # write result into IOStream
-    write(file, "\n$(fname)(X::Array{$(T[1])}, Y::Array{$(T[2])}) = $(fbest)(X, Y)\n")
-    println("BENCHMARK: $(fname)(Array{$(T[1])}, Array{$(T[2])}) mapped to $(fbest)()\n")
+    write(file, "\n$(fname)(X::$(T[1]), Y::$(T[2])) = $(fbest)(X, Y)\n")
+    println("BENCHMARK: $(fname)($(T[1]), $(T[2])) mapped to $(fbest)()\n")
 end
 
 
@@ -113,18 +113,18 @@ IOstream `file`.
     N: the length of the vector to benchmark over.
 """
 function benchmarkThreeArgFunction(fname, fnames,
-                                   T::Tuple{DataType, DataType, DataType}, file::IOStream, N::Integer)
+                                   T, file::IOStream, N::Integer)
 
     # dictionary to store elapsed values
     val = Dict()
-    println("TESTING: $(fname)(Array{$(T[1])}, Array{$(T[2])}, Array{$(T[3])})")
+    println("TESTING: $(fname)($(T[1]), $(T[2]), $(T[3]))")
 
     # Iterate over all functions
     for fstr in fnames
         f = eval(Meta.parse(fstr)) # convert string to function
-        X = randn(T[1], N) # function arguments
-        Y = randn(T[2], N) # function arguments
-        Z = randn(T[3], N) # function arguments
+        X = randn(eltype(T[1]), N) # function arguments
+        Y = randn(eltype(T[2]), N) # function arguments
+        Z = randn(eltype(T[3]), N) # function arguments
         f(X, Y, Z) # force compilation
         time = 0
         for i in 1:10 # benchmark 10 times
@@ -146,8 +146,8 @@ function benchmarkThreeArgFunction(fname, fnames,
     end
 
         # write result into IOStream
-    write(file, "\n$(fname)(X::Array{$(T[1])}, Y::Array{$(T[2])}, Z::Array{$(T[3])}) = $(fbest)(X, Y, Z)\n")
-    println("BENCHMARK: $(fname)(Array{$(T[1])}, Array{$(T[2])}, Array{$(T[3])}) mapped to $(fbest)()\n")
+    write(file, "\n$(fname)(X::$(T[1]), Y::$(T[2]), Z::$(T[3])) = $(fbest)(X, Y, Z)\n")
+    println("BENCHMARK: $(fname)($(T[1]), $(T[2]), $(T[3])) mapped to $(fbest)()\n")
 end
 
 """

--- a/deps/unix.jl
+++ b/deps/unix.jl
@@ -1,18 +1,18 @@
 include("helper.jl")
 
-# Locate and/or download Yeppp! 
+# Locate and/or download Yeppp!
 if isfile("$(pkgdir)deps/downloads/yeppp-1.0.0.tar.bz2") || (Libdl.find_library(["libyeppp"]) != "")
 else
-    info("====== Installing Yeppp! into local directory ======")
+    @info("====== Installing Yeppp! into local directory ======")
     trycmd(`mkdir $(pkgdir)deps/downloads`, err="Unable to create Vectorize/deps/downloads")
     trycmd(`mkdir $(pkgdir)deps/src`, err="Unable to create Vectorize/src/")
     trycmd(`mkdir $(pkgdir)deps/src/yeppp`, err="Unable to create Vectorize/src/yeppp")
     yeppploc = "http://bitbucket.org/MDukhan/yeppp/downloads/yeppp-1.0.0.tar.bz2"
-    @static if is_apple()
+    @static if Sys.isapple()
         run(pipeline(`curl -L $(yeppploc)`, stdout="$(pkgdir)deps/downloads/yeppp-1.0.0.tar.bz2"))
     else
         trycmd(`wget -P downloads $(yeppploc)`, err="Unable to download Yeppp!")
     end
     trycmd(`tar -xjvf $(pkgdir)deps/downloads/yeppp-1.0.0.tar.bz2 -C $(pkgdir)deps/src/yeppp --strip-components=1`)
-    info("====== Successfully installed Yeppp! ======")
+    @info("====== Successfully installed Yeppp! ======")
 end

--- a/deps/windows.jl
+++ b/deps/windows.jl
@@ -1,14 +1,14 @@
 include("helper.jl")
 
-# Locate and/or download Yeppp! 
+# Locate and/or download Yeppp!
 if isfile("$(pkgdir)deps\\downloads\\yeppp-1.0.0.tar.bz2") || (Libdl.find_library(["libyeppp"]) != "")
 else
-    info("====== Installing Yeppp! into local directory ======")
+    @info("====== Installing Yeppp! into local directory ======")
     trycmd(`cmd /C mkdir $(pkgdir)deps\\downloads`, err="Unable to create Vectorize/deps/downloads")
     trycmd(`cmd /C mkdir $(pkgdir)deps\\src`, err="Unable to create Vectorize/src/")
     trycmd(`wget64 -P downloads http://bitbucket.org/MDukhan/yeppp/downloads/yeppp-1.0.0.tar.bz2`, err="Unable to download Yeppp!")
     trycmd(`7z x $(pkgdir)deps\\downloads\\yeppp-1.0.0.tar.bz2 -o$(pkgdir)deps\\downloads\\`, err="Unable to decompress tar archive")
     trycmd(`7z x $(pkgdir)deps\\downloads\\yeppp-1.0.0.tar -o$(pkgdir)deps\\src\\`, err="Unable to expand tar archive")
     trycmd(`cmd /C move $(pkgdir)deps\\src\\yeppp-1.0.0 $(pkgdir)deps\\src\\yeppp`, err="Unable to rename Yeppp folder")
-    info("====== Successfully installed Yeppp! ======")
+    @info("====== Successfully installed Yeppp! ======")
 end

--- a/doc/functions.rst
+++ b/doc/functions.rst
@@ -1,621 +1,633 @@
 Functions
-========== 
+==========
 
 .. function:: sin(X)
 
 	      Computes the element-wise sine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: sin!(result, X)
 
 	      Computes the element-wise sine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(result::Array{Float32}, X::Array{Float32})
+		VML(result::Array{Float64}, X::Array{Float64})
+		VML(result::Array{Float32}, X::Array{Complex{Float32}})
+		VML(result::Array{Float64}, X::Array{Complex{Float64}})
+		Yeppp(result::Array{Float64}, X::Array{Float64})
+		Accelerate(result::Array{Float32}, X::Array{Float32})
+		Accelerate(result::Array{Float64}, X::Array{Float64})
 
 
 .. function:: cos(X)
 
 	      Computes the element-wise cosine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: cos!(result, X)
 
 	      Computes the element-wise cosine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(result::Array{Float32}, X::Array{Float32})
+		VML(result::Array{Float64}, X::Array{Float64})
+		VML(result::Array{Complex{Float32}}}, X::Array{Complex{Float32}})
+		VML(result::Array{Complex{Float64}}}, X::Array{Complex{Float64}})
+		Yeppp(result::Array{Float64}, X::Array{Float64})
+		Accelerate(result::Array{Float32}, X::Array{Float32})
+		Accelerate(result::Array{Float64}, X::Array{Float64})
 
 .. function:: tan(X)
 
 	      Computes the element-wise tangent of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: tan!(result, X)
 
 	      Computes the element-wise tangent of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 
 .. function:: asin(X)
 
 	      Computes the element-wise inverse sine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: asin!(result, X)
 
 	      Computes the element-wise inverse sine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
-		
+
 
 .. function:: acos(X)
 
 	      Computes the element-wise inverse cosine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: acos!(result, X)
 
 	      Computes the element-wise inverse cosine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: atan(X)
 
 	      Computes the element-wise inverse tangent of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: atan!(result, X)
 
 	      Computes the element-wise inverse tangent of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: sinh(X)
 
 	      Computes the element-wise hyperbolic sine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: sinh!(result, X)
 
 	      Computes the element-wise hyperbolic sine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: cosh(X)
 
 	      Computes the element-wise hyperbolic cosine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: cosh!(result, X)
 
 	      Computes the element-wise cosine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: tanh(X)
 
 	      Computes the element-wise hyperbolic tangent of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: tanh!(result, X)
 
 	      Computes the element-wise hyperbolic tangent of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: asinh(X)
 
 	      Computes the element-wise inverse hyperbolic sine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: asinh!(result, X)
 
 	      Computes the element-wise inverse hyperbolic sine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: acosh(X)
 
 	      Computes the element-wise inverse hyperbolic cosine of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: acosh!(result, X)
 
 	      Computes the element-wise inverse hyperbolic cosine of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: atanh(X)
 
 	      Computes the element-wise inverse hyperbolic tangent of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float64})
 
 .. function:: atanh!(result, X)
 
 	      Computes the element-wise inverse hyperbolic tangent of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 
 .. function:: sinpi(X)
 
 	      Computes the element-wise sine of `pi` times a vector::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
-		
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
+
 .. function:: sinpi!(result, X)
 
 	      Computes the element-wise sine of `pi` times a vector and stores it in result::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 
 .. function:: cospi(X)
 
 	      Computes the element-wise cosine of `pi` times a vector::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
-		
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
+
 .. function:: cospi!(result, X)
 
 	      Computes the element-wise cosine of `pi` times a vector and stores it in result::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: tanpi(X)
 
 	      Computes the element-wise tangent of `pi` times a vector::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
-		
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
+
 .. function:: tanpi!(result, X)
 
 	      Computes the element-wise tangent of `pi` times a vector and stores it in result::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: atan2(X, Y)
 
 	      Computes the element-wise arctangent two vectors::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: atan2!(result, X, Y)
 
 	      Computes the element-wise arctangent two vectors and stores it in result::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: log(X)
 
 	      Computes the element-wise logarithm of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: log!(result, X)
 
 	      Computes the element-wise logarithm of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 
 .. function:: log10(X)
 
 	      Computes the element-wise logarithm to base-10 of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: log10!(result, X)
 
 	      Computes the element-wise logarithm to base-10 of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: log1p(X)
 
 	      Computes the element-wise natural logarithm to one plus a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: log1p!(result, X)
 
 	      Computes the element-wise natural logarithm of one plus a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 
 .. function:: log2(X)
 
 	      Computes the element-wise logarithm to base-2 of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: log2!(result, X)
 
 	      Computes the element-wise logarithm to base-2 of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: exp(X)
 
 	      Computes the element-wise base-e exponent of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: exp!(result, X)
 
 	      Computes the element-wise base-e exponent of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: exp2(X)
 
 	      Computes the element-wise base-2 exponent of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: exp2!(result, X)
 
 	      Computes the element-wise base-2 exponent of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: expm1(X)
 
 	      Computes the element-wise natural exponent of a vector minus one::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: expm1!(result, X)
 
 	      Computes the element-wise natural exponent of a vector minus one and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: pow(X, Y)
 
-	      Calculates a vector raised element-wise to the power of another vector::
+	      Calculates a vector raised element-wise to the power of another vector, or to a scalar::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
+		VML(X::Array{Float32}, Y::Float32)
+		VML(X::Array{Float64}, Y::Float64)
+		VML(X::Array{Complex{Float32}}, Y::Complex{Float32})
+		VML(X::Array{Complex{Float64}}, Y::Complex{Float64})
 
 .. function:: pow!(result, X, Y)
 
 	      Calculates a vector raised element-wise to the power of another vector and stores it in result::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
+		VML(result::Array{Float32}, X::Array{Float32}, Y::Array{Float32})
+		VML(result::Array{Float64}, X::Array{Float64}, Y::Array{Float64})
+		VML(result::Array{Complex{Float32}}, X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(result::Array{Complex{Float64}}, X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
+		VML(result::Array{Float32}, X::Array{Float32}, Y::Float32)
+		VML(result::Array{Float64}, X::Array{Float64}, Y::Float64)
+		VML(result::Array{Complex{Float32}}, X::Array{Complex{Float32}}, Y::Complex{Float32})
+		VML(result::Array{Complex{Float64}}, X::Array{Complex{Float64}}, Y::Complex{Float64})
 
 .. function:: pow2o3(X)
 
 	      Raises each element of a vector to the `2/3` power::
 
-		VML(X::Float32)
-		VML(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
 
 .. function:: pow2o3!(result, X)
 
 	      Raises each element of a vector to the `2/3` power stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
 
 .. function:: pow3o2(X)
 
 	      Raises each element of a vector to the `3/3` power::
 
-		VML(X::Float32)
-		VML(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
 
 .. function:: pow3o2!(result, X)
 
 	      Raises each element of a vector to the `3/2` power stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
 
 .. function:: exponent(X)
 
 	      Computes the element-wise exponent of a vector::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: exponent!(result, X)
 
 	      Computes element-wise exponent of a vector and stores it in result::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: sqrt(X)
 
 	      Computes the element-wise square root of a vector minus one::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: sqrt!(result, X)
 
 	      Computes the element-wise square root of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Yeppp(X::Float64)
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Yeppp(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: invsqrt(X)
 
 	      Computes the element-wise square root of a vector minus one::
 
-		VML(X::Float32)
-		VML(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
 
 .. function:: invsqrt!(result, X)
 
 	      Computes the element-wise square root of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
 
 .. function:: invsqrt(X)
 
 	      Computes the element-wise square root of a vector minus one::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: invsqrt!(result, X)
 
 	      Computes the element-wise square root of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: add(X, Y)
 
 	      Computes the element-wise addition two vectors::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
 		Yeppp(X::Int8, Y::Int8)
 		Yeppp(X::UInt8, Y::UInt8)
 		Yeppp(X::Int16, Y::Int16)
@@ -623,19 +635,19 @@ Functions
 		Yeppp(X::Int32, Y::Int32)
 		Yeppp(X::UInt32, Y::UInt32)
 		Yeppp(X::Int64, Y::Int64)
-		Yeppp(X::Float32, Y::Float32)
-		Yeppp(X::Float64, Y::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		Yeppp(X::Array{Float32}, Y::Array{Float32})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: add!(result, X, Y)
 
 	      Computes the element-wise addition of two vectors and stores it in result::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
 		Yeppp(X::Int8, Y::Int8)
 		Yeppp(X::UInt8, Y::UInt8)
 		Yeppp(X::Int16, Y::Int16)
@@ -643,20 +655,20 @@ Functions
 		Yeppp(X::Int32, Y::Int32)
 		Yeppp(X::UInt32, Y::UInt32)
 		Yeppp(X::Int64, Y::Int64)
-		Yeppp(X::Float32, Y::Float32)
-		Yeppp(X::Float64, Y::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		Yeppp(X::Array{Float32}, Y::Array{Float32})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 
 .. function:: sub(X, Y)
 
 	      Computes the element-wise subtraction two vectors::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
 		Yeppp(X::Int8, Y::Int8)
 		Yeppp(X::UInt8, Y::UInt8)
 		Yeppp(X::Int16, Y::Int16)
@@ -664,19 +676,19 @@ Functions
 		Yeppp(X::Int32, Y::Int32)
 		Yeppp(X::UInt32, Y::UInt32)
 		Yeppp(X::Int64, Y::Int64)
-		Yeppp(X::Float32, Y::Float32)
-		Yeppp(X::Float64, Y::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		Yeppp(X::Array{Float32}, Y::Array{Float32})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: sub!(result, X, Y)
 
 	      Computes the element-wise subtraction of two vectors and stores it in result::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
 		Yeppp(X::Int8, Y::Int8)
 		Yeppp(X::UInt8, Y::UInt8)
 		Yeppp(X::Int16, Y::Int16)
@@ -684,20 +696,20 @@ Functions
 		Yeppp(X::Int32, Y::Int32)
 		Yeppp(X::UInt32, Y::UInt32)
 		Yeppp(X::Int64, Y::Int64)
-		Yeppp(X::Float32, Y::Float32)
-		Yeppp(X::Float64, Y::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		Yeppp(X::Array{Float32}, Y::Array{Float32})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 
 .. function:: mul(X, Y)
 
 	      Computes the element-wise multiplication two vectors::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
 		Yeppp(X::Int8, Y::Int8)
 		Yeppp(X::UInt8, Y::UInt8)
 		Yeppp(X::Int16, Y::Int16)
@@ -705,19 +717,19 @@ Functions
 		Yeppp(X::Int32, Y::Int32)
 		Yeppp(X::UInt32, Y::UInt32)
 		Yeppp(X::Int64, Y::Int64)
-		Yeppp(X::Float32, Y::Float32)
-		Yeppp(X::Float64, Y::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		Yeppp(X::Array{Float32}, Y::Array{Float32})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: mul!(result, X, Y)
 
 	      Computes the element-wise multiplication of two vectors and stores it in result::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
 		Yeppp(X::Int8, Y::Int8)
 		Yeppp(X::UInt8, Y::UInt8)
 		Yeppp(X::Int16, Y::Int16)
@@ -725,102 +737,110 @@ Functions
 		Yeppp(X::Int32, Y::Int32)
 		Yeppp(X::UInt32, Y::UInt32)
 		Yeppp(X::Int64, Y::Int64)
-		Yeppp(X::Float32, Y::Float32)
-		Yeppp(X::Float64, Y::Float64)
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		Yeppp(X::Array{Float32}, Y::Array{Float32})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 
 .. function:: div(X, Y)
 
 	      Computes the element-wise division two vectors::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: div!(result, X, Y)
 
 	      Computes the element-wise division of two vectors and stores it in result::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
-		VML(X::Complex{Float32}, Y::Complex{Float32})
-		VML(X::Complex{Float64}, Y::Complex{Float64})
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		VML(X::Array{Complex{Float32}}, Y::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}}, Y::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: abs(X)
 
 	      Computes the element-wise absolute value of a vector::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: abs!(result, X)
 
 	      Computes the element-wise absolute value of a vector and stores it in result::
 
-		VML(X::Float32)
-		VML(X::Float64)
-		VML(X::Complex{Float32})
-		VML(X::Complex{Float64})
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		VML(X::Array{Complex{Float32}})
+		VML(X::Array{Complex{Float64}})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: max(X, Y)
 
 	      Computes the element-wise maximum value of two vectors::
 
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
-		Yeppp(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: max!(result, X, Y)
 
 	      Computes the element-wise maximum value of two vectors and stores it in result::
 
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
-	      	Yeppp(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
+	      	Yeppp(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: min(X, Y)
 
 	      Computes the element-wise minimum value of two vectors::
 
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
-		Yeppp(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: min!(result, X, Y)
 
 	      Computes the element-wise minimum value of two vectors and stores it in result::
 
-		Accelerate(X::Float32, Y::Float32)
-		Accelerate(X::Float64, Y::Float64)
-		Yeppp(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
+		Accelerate(X::Array{Float32}, Y::Array{Float32})
+		Accelerate(X::Array{Float64}, Y::Array{Float64})
+		Yeppp(X::Array{Float64}, Y::Array{Float64})
 
 
 .. function:: maximum(X)
 
 	      Returns the maximum value contained within a vector::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 .. function:: mininum(X)
 
 	      Returns the minimum value contained within a vector::
 
-		Accelerate(X::Float32)
-		Accelerate(X::Float64)
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
 
 
 
@@ -828,12 +848,25 @@ Functions
 
 	      Computes the element-wise hypotenuse of a triangle with sides given by two vectors::
 
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
+		VML(X::Array{Float32}, Y::Array{Float32})
+		VML(X::Array{Float64}, Y::Array{Float64})
 
 .. function:: hypot!(result, X, Y)
 
 	      Computes the element-wise hypotenuse of a triangle with sides given by two vectors and stores it in result::
-		VML(X::Float32, Y::Float32)
-		VML(X::Float64, Y::Float64)
+		VML(result::Array{Float32}, X::Array{Float32}, Y::Array{Float32})
+		VML(result::Array{Float64}, X::Array{Float64}, Y::Array{Float64})
 
+.. function:: cis(X)
+				Computes the element-wise cosine-imaginary-sin of the vector X
+		VML(X::Array{Float32})
+		VML(X::Array{Float64})
+		Accelerate(X::Array{Float32})
+		Accelerate(X::Array{Float64})
+
+.. function:: cis!(result, X)
+				Computes the element-wise cosine-imaginary-sin of the vector Xand stores it in results::
+		VML(result::Array{Complex{Float32}}, X::Array{Float32})
+		VML(result::Array{Complex{Float64}}, X::Array{Float64})
+		Accelerate(result::Array{Complex{Float32}}, X::Array{Float32})
+		Accelerate(result::Array{Complex{Float64}}, X::Array{Float64})

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,14 +18,23 @@ Furthermore, a complete benchmarking suite is run during package installation th
 
 will be transparently mapped to the Accelerate, VML or Yeppp! implementation based upon the performance of these frameworks on *your particular machine* and the type of ``X``. This mapping happens during package installation and so occurs no runtime overhead (expect to wait a few extra seconds than normal to install this package as the benchmarking suite needs to be run).
 
-Lastly, Vectorize.jl provides a ``@vectorize`` macro that automatically converts a call to Julia's standard implementation into the fastest vectorized equivalent available on your machine, i.e.::
+Vectorize.jl provides a ``@vectorize`` macro that automatically converts a call to Julia's standard implementation into the fastest vectorized equivalent available on your machine, i.e.::
 
     cos(X)    # Standard Julia implementation
     @vectorize cos(X)    # Converted to Yeppp, VML, or Accelerate at compile time
 
-This macro provides an easy method for code to be quickly converted to use Vectorize.jl with little additional effort. 
+This macro provides an easy method for code to be quickly converted to use Vectorize.jl with little additional effort.
 
-These functions can provide orders of magnitude higher-performance than the standard functions in Julia; over 10-fold improvements are common for functions throughout the three libraries. Since these functions are designed to operate on moderate-to-large sized arrays, they tend to be less performant that standard Julia functions for arrays of length less than 10 elements; in that case, it is best not to use Vectorize.jl. 
+Vectorize.jl also provides a ``@replacebase`` macro that automatically overloads base broadcasting calls into the fastest vectorized equivalent available.
+
+   X.^(-1/3)  # Standard Julia broadcast implementation
+   Z .= cis.(X)   # Standard Julia in-place broadcast implementation
+   @replacebase cis # Overloads both in-place and out-of-place broadcast calls to cis, provided cis is not fused in the broadcast
+   @replacebase ^
+   X.^(-1/3)  # This call now uses Vectorize.pow(X, -1/3)
+   Z .= cis.(X)   # This call now uses Vectorize.cis!
+
+These functions can provide orders of magnitude higher-performance than the standard functions in Julia; over 10-fold improvements are common for functions throughout the three libraries. Since these functions are designed to operate on moderate-to-large sized arrays, they tend to be less performant that standard Julia functions for arrays of length less than 10 elements; in that case, it is best not to use Vectorize.jl.
 
 Vectorize.jl will transparently select from the different frameworks that are available on your machine; you are not required to have any particular framework installed (although having all three tends to provide the best performance as different frameworks have different strengths). For users not running OS X, we strongly recommend installing Intel's VML (free for open-source projects under the community license - other licenses are available) as the only other library available for non-OSX systems is Yeppp, and Yeppp only provides a very small collection of functions.
 
@@ -39,7 +48,7 @@ This package currently supports over 40 functions over ``Float32``, ``Float64``,
    functions
    devdocs
 
-   
+
 
 ..
    Indices and tables
@@ -48,4 +57,3 @@ This package currently supports over 40 functions over ``Float32``, ``Float64``,
    * :ref:`genindex`
    * :ref:`modindex`
    * :ref:`search`
-

--- a/src/Accelerate.jl
+++ b/src/Accelerate.jl
@@ -33,8 +33,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     for (f, fa) in veclibfunctions
         name = string(f)
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (T,T)), "Vectorize.Accelerate.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T})), "Vectorize.Accelerate.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Vector{$($T)})`
@@ -61,8 +61,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # 2 arg functions
     for f in (:copysign,)
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
@@ -80,8 +80,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # for some bizarre reason, vvpow/vvpowf reverse the order of arguments.
     for f in (:pow,)
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
@@ -100,8 +100,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # renamed 2 arg functions
     for (f,fa) in ((:rem,:fmod),(:fdiv,:div),(:atan,:atan2))
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
@@ -119,8 +119,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # two-arg return
     for f in (:sincos,)
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T})
                 out1 = similar(X)
@@ -138,8 +138,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # complex return
     for (f,fa) in ((:cis,:cosisin),)
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (Complex{T},T)), "Vectorize.Accelerate.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{Complex{T}},Array{T})), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T})
                 out = Array{Complex{$T}}(undef, size(X))
@@ -172,8 +172,8 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
 
     for (f, fa, name) in vDSPfunctions
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$f!")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.Accelerate.$f!")
         @eval begin
             @doc """
             `$($f)(X::Vector{$($T)}, Y::Vector{$($T)})`
@@ -216,7 +216,7 @@ const vDSPscalar = ((:sum,  :sve, "sum"), (:summag, :svemg, "sum-of-magnitudes")
 for (T, suff) in ((Float64, "D"), (Float32, ""))
 
     for (f, fa, name) in vDSPscalar
-        addfunction(functions, (f, (T,)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.Accelerate.$f")
         @eval begin
             @doc """
             `$($f)(X::Vector{$($T)}, Y::Vector{$($T)})`

--- a/src/Accelerate.jl
+++ b/src/Accelerate.jl
@@ -19,7 +19,7 @@ const libacc = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
 ## This assumes arguments of the form (output_vector, input_vector, length)
 ##
 const veclibfunctions =
-    ((:ceil, :ceil), (:floor, :floor), (:sqrt, :sqrt), (:invsqrt, :rsqrt), (:rec, :rec),
+    ((:ceil, :ceil), (:floor, :floor), (:sqrt, :sqrt), (:invsqrt, :rsqrt), (:inv, :rec),
      (:exp, :exp), (:exp2, :exp2), (:expm1, :expm1), (:log, :log), (:log1p, :log1p),
      (:log2, :log2), (:log10, :log10), (:sin, :sin), (:sinpi, :sinpi), (:cos, :cos),
      (:cospi, :cospi), (:tan, :tan), (:tanpi, :tanpi), (:asin, :asin), (:acos, :acos),

--- a/src/Accelerate.jl
+++ b/src/Accelerate.jl
@@ -61,6 +61,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # 2 arg functions
     for f in (:copysign,)
         f! = Symbol("$(f)!")
+        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
@@ -78,6 +80,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # for some bizarre reason, vvpow/vvpowf reverse the order of arguments.
     for f in (:pow,)
         f! = Symbol("$(f)!")
+        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
@@ -96,6 +100,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # renamed 2 arg functions
     for (f,fa) in ((:rem,:fmod),(:fdiv,:div),(:atan,:atan2))
         f! = Symbol("$(f)!")
+        addfunction(functions, (f, (T,T)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T}, Y::Array{$T})
                 size(X) == size(Y) || throw(DimensionMismatch("Arguments must have same shape"))
@@ -113,6 +119,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # two-arg return
     for f in (:sincos,)
         f! = Symbol("$(f)!")
+        addfunction(functions, (f, (T,)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (T,T,T)), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T})
                 out1 = similar(X)
@@ -130,6 +138,8 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     # complex return
     for (f,fa) in ((:cis,:cosisin),)
         f! = Symbol("$(f)!")
+        addfunction(functions, (f, (T,)), "Vectorize.Accelerate.$f")
+        addfunction(functions, (f!, (Complex{T},T)), "Vectorize.Accelerate.$(f!)")
         @eval begin
             function ($f)(X::Array{$T})
                 out = Array{Complex{$T}}(undef, size(X))

--- a/src/Accelerate.jl
+++ b/src/Accelerate.jl
@@ -40,7 +40,7 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
             `$($f)(X::Vector{$($T)})`
             Implements element-wise **$($name)** over a **Vector{$($T)}**. Allocates
             memory to store result. *Returns:* **Vector{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 out = similar(X)
                 return ($f!)(out, X)
@@ -49,11 +49,11 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
             `$($f!)(result::Vector{$($T)}, X::Vector{$($T)})`
             Implements element-wise **$($name)** over a **Vector{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T})
-                ccall(($(string("vv", fa,suff)),libacc),Void,
+                ccall(($(string("vv", fa,suff)),libacc),Cvoid,
                       (Ptr{$T},Ptr{$T},Ptr{Cint}),
-                      out,X,&length(X))
+                      out,X,Ref{Cint}(length(X)))
                 return out
             end
         end
@@ -84,9 +84,9 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             `$($f)(X::Vector{$($T)}, Y::Vector{$($T)})`
             Implements element-wise **$($name)** over two **Vector{$($T)}**. Allocates
             memory to store result. *Returns:* **Vector{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T}, Y::Array{$T})
-                out = Array($T, length(X))
+                out = Array{$T}(undef, length(X))
                 return ($f!)(out, Y, X)
             end
         end
@@ -95,9 +95,9 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             `$($f!)(result::Vector{$($T)}, X::Vector{$($T)}, Y::Vector{$($T)})`
             Implements element-wise **$($name)** over two **Vector{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
-                ccall(($(string("vDSP_", fa,suff)),libacc), Void,
+                ccall(($(string("vDSP_", fa,suff)),libacc), Cvoid,
                       (Ptr{$T},Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Int64),
                       X, 1, Y, 1, out, 1, length(out))
                 return out
@@ -127,10 +127,10 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             `$($f)(X::Vector{$($T)}, Y::Vector{$($T)})`
             Computes the **$($name)** of a **Vector{$($T)}**.
             *Returns:* **$($T)**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 out = Ref{$T}(0.0)
-                ccall(($(string("vDSP_", fa,suff)),libacc),Void,
+                ccall(($(string("vDSP_", fa,suff)),libacc),Cvoid,
                       (Ptr{$T},Cint, Ref{$T}, Cint),
                       X, 1, out, length(X))
                 return out[]
@@ -145,11 +145,11 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             `$($f)(X::Vector{$($T)})`
             Computes the **$($name)** element-wise over a **Vector{$($T)}**.
             *Returns:* **$(($T, UInt64))**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 index = Ref{Int}(0)
                 val = Ref{$T}(0.0)
-                ccall(($(string("vDSP_", fa, suff), libacc)),  Void,
+                ccall(($(string("vDSP_", fa, suff), libacc)),  Cvoid,
                       (Ptr{$T}, Int64,  Ref{$T}, Ref{Int}, UInt64),
                       X, 1, val, index, length(X))
                 return (val[], index[]+1)

--- a/src/Functions.jl
+++ b/src/Functions.jl
@@ -1,1 +1,320 @@
-## This file will be automatically completed during the package build process
+
+acosh(X::Array{Float32}) = Vectorize.Accelerate.acosh(X)
+
+sub!(X::Array{Float64}, Y::Array{Float64}, Z::Array{Float64}) = Vectorize.Accelerate.sub!(X, Y, Z)
+
+atanh(X::Array{Float32}) = Vectorize.Accelerate.atanh(X)
+
+round(X::Array{Float32}) = Vectorize.Accelerate.round(X)
+
+sinpi(X::Array{Float32}) = Vectorize.Accelerate.sinpi(X)
+
+acos!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.acos!(X, Y)
+
+log(X::Array{Float32}) = Vectorize.Accelerate.log(X)
+
+log!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.log!(X, Y)
+
+log2!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.log2!(X, Y)
+
+sub(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.sub(X, Y)
+
+expm1(X::Array{Float64}) = Vectorize.Accelerate.expm1(X)
+
+mul(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.mul(X, Y)
+
+atan!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.atan!(X, Y)
+
+sqrt!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.sqrt!(X, Y)
+
+exp!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.exp!(X, Y)
+
+max!(X::Array{Float32}, Y::Array{Float32}, Z::Array{Float32}) = Vectorize.Accelerate.max!(X, Y, Z)
+
+log2(X::Array{Float64}) = Vectorize.Accelerate.log2(X)
+
+abs!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.abs!(X, Y)
+
+sinpi!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.sinpi!(X, Y)
+
+asin!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.asin!(X, Y)
+
+rec(X::Array{Float64}) = Vectorize.Accelerate.rec(X)
+
+sqrt(X::Array{Float64}) = Vectorize.Accelerate.sqrt(X)
+
+div(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.div(X, Y)
+
+log2(X::Array{Float32}) = Vectorize.Accelerate.log2(X)
+
+asinh(X::Array{Float32}) = Vectorize.Accelerate.asinh(X)
+
+tanpi!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.tanpi!(X, Y)
+
+floor(X::Array{Float32}) = Vectorize.Accelerate.floor(X)
+
+exp2(X::Array{Float64}) = Vectorize.Accelerate.exp2(X)
+
+expm1(X::Array{Float32}) = Vectorize.Accelerate.expm1(X)
+
+cosh(X::Array{Float32}) = Vectorize.Accelerate.cosh(X)
+
+sub(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.sub(X, Y)
+
+asin(X::Array{Float64}) = Vectorize.Accelerate.asin(X)
+
+rec!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.rec!(X, Y)
+
+log1p(X::Array{Float32}) = Vectorize.Accelerate.log1p(X)
+
+floor(X::Array{Float64}) = Vectorize.Accelerate.floor(X)
+
+invsqrt!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.invsqrt!(X, Y)
+
+min!(X::Array{Float64}, Y::Array{Float64}, Z::Array{Float64}) = Vectorize.Accelerate.min!(X, Y, Z)
+
+min(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.min(X, Y)
+
+div!(X::Array{Float64}, Y::Array{Float64}, Z::Array{Float64}) = Vectorize.Accelerate.div!(X, Y, Z)
+
+cos(X::Array{Float64}) = Vectorize.Accelerate.cos(X)
+
+cospi(X::Array{Float32}) = Vectorize.Accelerate.cospi(X)
+
+round!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.round!(X, Y)
+
+mean(X::Array{Float64}) = Vectorize.Accelerate.mean(X)
+
+rec!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.rec!(X, Y)
+
+sqrt!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.sqrt!(X, Y)
+
+summag(X::Array{Float32}) = Vectorize.Accelerate.summag(X)
+
+add(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.add(X, Y)
+
+sum(X::Array{Float64}) = Vectorize.Accelerate.sum(X)
+
+exp!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.exp!(X, Y)
+
+ceil(X::Array{Float64}) = Vectorize.Accelerate.ceil(X)
+
+ceil!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.ceil!(X, Y)
+
+trunc!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.trunc!(X, Y)
+
+ceil(X::Array{Float32}) = Vectorize.Accelerate.ceil(X)
+
+asinh!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.asinh!(X, Y)
+
+exponent(X::Array{Float32}) = Vectorize.Accelerate.exponent(X)
+
+cosh!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.cosh!(X, Y)
+
+asinh(X::Array{Float64}) = Vectorize.Accelerate.asinh(X)
+
+abs!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.abs!(X, Y)
+
+exponent!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.exponent!(X, Y)
+
+log1p!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.log1p!(X, Y)
+
+acos!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.acos!(X, Y)
+
+cospi!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.cospi!(X, Y)
+
+cospi(X::Array{Float64}) = Vectorize.Accelerate.cospi(X)
+
+add!(X::Array{Float32}, Y::Array{Float32}, Z::Array{Float32}) = Vectorize.Accelerate.add!(X, Y, Z)
+
+exp2(X::Array{Float32}) = Vectorize.Accelerate.exp2(X)
+
+acos(X::Array{Float64}) = Vectorize.Accelerate.acos(X)
+
+asin!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.asin!(X, Y)
+
+log10(X::Array{Float32}) = Vectorize.Accelerate.log10(X)
+
+sum(X::Array{Float32}) = Vectorize.Accelerate.sum(X)
+
+minimum(X::Array{Float32}) = Vectorize.Accelerate.minimum(X)
+
+log10!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.log10!(X, Y)
+
+trunc(X::Array{Float32}) = Vectorize.Accelerate.trunc(X)
+
+log!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.log!(X, Y)
+
+invsqrt(X::Array{Float32}) = Vectorize.Accelerate.invsqrt(X)
+
+atan(X::Array{Float64}) = Vectorize.Accelerate.atan(X)
+
+sinh!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.sinh!(X, Y)
+
+sqrt(X::Array{Float32}) = Vectorize.Accelerate.sqrt(X)
+
+tanpi!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.tanpi!(X, Y)
+
+abs(X::Array{Float64}) = Vectorize.Accelerate.abs(X)
+
+atan!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.atan!(X, Y)
+
+invsqrt!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.invsqrt!(X, Y)
+
+log10!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.log10!(X, Y)
+
+atanh!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.atanh!(X, Y)
+
+atanh(X::Array{Float64}) = Vectorize.Accelerate.atanh(X)
+
+sinpi(X::Array{Float64}) = Vectorize.Accelerate.sinpi(X)
+
+cospi!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.cospi!(X, Y)
+
+tan!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Yeppp.tan!(X, Y)
+
+rec(X::Array{Float32}) = Vectorize.Accelerate.rec(X)
+
+log(X::Array{Float64}) = Vectorize.Accelerate.log(X)
+
+sin(X::Array{Float32}) = Vectorize.Accelerate.sin(X)
+
+asin(X::Array{Float32}) = Vectorize.Accelerate.asin(X)
+
+div!(X::Array{Float32}, Y::Array{Float32}, Z::Array{Float32}) = Vectorize.Accelerate.div!(X, Y, Z)
+
+exp2!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.exp2!(X, Y)
+
+round!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.round!(X, Y)
+
+tanh!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.tanh!(X, Y)
+
+max(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.max(X, Y)
+
+mul!(X::Array{Float32}, Y::Array{Float32}, Z::Array{Float32}) = Vectorize.Accelerate.mul!(X, Y, Z)
+
+sub!(X::Array{Float32}, Y::Array{Float32}, Z::Array{Float32}) = Vectorize.Accelerate.sub!(X, Y, Z)
+
+tan!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.tan!(X, Y)
+
+sin!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.sin!(X, Y)
+
+sumsqr(X::Array{Float32}) = Vectorize.Accelerate.sumsqr(X)
+
+asinh!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.asinh!(X, Y)
+
+atanh!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.atanh!(X, Y)
+
+ceil!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.ceil!(X, Y)
+
+cos!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.cos!(X, Y)
+
+mul(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.mul(X, Y)
+
+expm1!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.expm1!(X, Y)
+
+add(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Yeppp.add(X, Y)
+
+summag(X::Array{Float64}) = Vectorize.Accelerate.summag(X)
+
+sinpi!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.sinpi!(X, Y)
+
+abs(X::Array{Float32}) = Vectorize.Accelerate.abs(X)
+
+log1p!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.log1p!(X, Y)
+
+cos(X::Array{Float32}) = Vectorize.Accelerate.cos(X)
+
+mean(X::Array{Float32}) = Vectorize.Accelerate.mean(X)
+
+cosh!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.cosh!(X, Y)
+
+sin(X::Array{Float64}) = Vectorize.Accelerate.sin(X)
+
+tan(X::Array{Float64}) = Vectorize.Yeppp.tan(X)
+
+max!(X::Array{Float64}, Y::Array{Float64}, Z::Array{Float64}) = Vectorize.Accelerate.max!(X, Y, Z)
+
+trunc(X::Array{Float64}) = Vectorize.Accelerate.trunc(X)
+
+tanh(X::Array{Float32}) = Vectorize.Accelerate.tanh(X)
+
+tanpi(X::Array{Float32}) = Vectorize.Accelerate.tanpi(X)
+
+div(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.div(X, Y)
+
+sumsqr(X::Array{Float64}) = Vectorize.Accelerate.sumsqr(X)
+
+minimum(X::Array{Float64}) = Vectorize.Accelerate.minimum(X)
+
+cosh(X::Array{Float64}) = Vectorize.Accelerate.cosh(X)
+
+max(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.max(X, Y)
+
+sinh(X::Array{Float32}) = Vectorize.Accelerate.sinh(X)
+
+maximum(X::Array{Float64}) = Vectorize.Accelerate.maximum(X)
+
+exponent!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.exponent!(X, Y)
+
+exp2!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.exp2!(X, Y)
+
+invsqrt(X::Array{Float64}) = Vectorize.Accelerate.invsqrt(X)
+
+acos(X::Array{Float32}) = Vectorize.Accelerate.acos(X)
+
+mul!(X::Array{Float64}, Y::Array{Float64}, Z::Array{Float64}) = Vectorize.Accelerate.mul!(X, Y, Z)
+
+exp(X::Array{Float32}) = Vectorize.Accelerate.exp(X)
+
+add!(X::Array{Float64}, Y::Array{Float64}, Z::Array{Float64}) = Vectorize.Accelerate.add!(X, Y, Z)
+
+log1p(X::Array{Float64}) = Vectorize.Accelerate.log1p(X)
+
+acosh!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.acosh!(X, Y)
+
+log2!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.log2!(X, Y)
+
+sinh(X::Array{Float64}) = Vectorize.Accelerate.sinh(X)
+
+acosh(X::Array{Float64}) = Vectorize.Accelerate.acosh(X)
+
+sin!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.sin!(X, Y)
+
+exp(X::Array{Float64}) = Vectorize.Accelerate.exp(X)
+
+exponent(X::Array{Float64}) = Vectorize.Accelerate.exponent(X)
+
+maximum(X::Array{Float32}) = Vectorize.Accelerate.maximum(X)
+
+min!(X::Array{Float32}, Y::Array{Float32}, Z::Array{Float32}) = Vectorize.Accelerate.min!(X, Y, Z)
+
+tanh!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.tanh!(X, Y)
+
+log10(X::Array{Float64}) = Vectorize.Accelerate.log10(X)
+
+floor!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.floor!(X, Y)
+
+expm1!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.expm1!(X, Y)
+
+tanh(X::Array{Float64}) = Vectorize.Accelerate.tanh(X)
+
+acosh!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.acosh!(X, Y)
+
+round(X::Array{Float64}) = Vectorize.Accelerate.round(X)
+
+cos!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Yeppp.cos!(X, Y)
+
+min(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.min(X, Y)
+
+tanpi(X::Array{Float64}) = Vectorize.Accelerate.tanpi(X)
+
+atan(X::Array{Float32}) = Vectorize.Accelerate.atan(X)
+
+floor!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.floor!(X, Y)
+
+tan(X::Array{Float32}) = Vectorize.Accelerate.tan(X)
+
+sinh!(X::Array{Float64}, Y::Array{Float64}) = Vectorize.Accelerate.sinh!(X, Y)
+
+trunc!(X::Array{Float32}, Y::Array{Float32}) = Vectorize.Accelerate.trunc!(X, Y)

--- a/src/VML.jl
+++ b/src/VML.jl
@@ -176,7 +176,7 @@ end
 for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  (Complex{Float64}, "z")]
     for (f, fvml) in [(:sqrt, :Sqrt), (:exp, :Exp),  (:acos, :Acos), (:asin, :Asin),
                       (:acosh, :Acosh), (:asinh, :Asinh), (:log,  :Ln),
-                     (:atan, :Atan), (:cos, :Cos), (:sin, :Sin),
+                     (:atan, :Atan), (:atanh, :Atanh), (:cos, :Cos), (:sin, :Sin),
                       (:tan, :Tan), (:cosh, :Cosh), (:sinh, :Sinh), (:tanh, :Tanh), (:log10, :Log10)]
         f! = Symbol("$(f)!")
         name = string(f)

--- a/src/VML.jl
+++ b/src/VML.jl
@@ -112,7 +112,8 @@ end
 
 # Real only returning real - two args
 for (T, prefix) in [(Float32, "s"),  (Float64, "d")]
-    for (f, fvml, name) in [(:hypot, :Hypot, "hypotenuse"), (:atan, :Atan2, "atan2")]
+    for (f, fvml, name) in [(:hypot, :Hypot, "hypotenuse"), (:atan, :Atan2, "atan2"),
+                            (:max, :Fmax, "max"), (:min, :Fmin, "min")]
         f! = Symbol("$(f)!")
         addfunction(functions, (f, (T,T)), "Vectorize.VML.$f")
         addfunction(functions, (f!, (T,T,T)), "Vectorize.VML.$(f!)")
@@ -142,8 +143,9 @@ for (T, prefix) in [(Float32, "s"),  (Float64, "d")]
 end
 
 # Complex only returning complex - two arg
+# note order change in c-call, in VML library the second argument is conjugated
 for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
-    for (f, fvml, name) in [(:mulbyconj, :MulByConj, "multiply-by-conjugate")]
+    for (f, fvml, name) in [(:dot, :MulByConj, "multiply-by-conjugate")]
         f! = Symbol("$(f)!")
         addfunction(functions, (f, (T,T)), "Vectorize.VML.$f")
         addfunction(functions, (f!, (T,T,T)), "Vectorize.VML.$(f!)")
@@ -165,7 +167,7 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
                 ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T},  Ptr{$T}),
-                      length(out), X, Y,  out)
+                      length(out), Y, X,  out)
                 return out
             end
         end
@@ -177,7 +179,8 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
     for (f, fvml) in [(:sqrt, :Sqrt), (:exp, :Exp),  (:acos, :Acos), (:asin, :Asin),
                       (:acosh, :Acosh), (:asinh, :Asinh), (:log,  :Ln),
                      (:atan, :Atan), (:atanh, :Atanh), (:cos, :Cos), (:sin, :Sin),
-                      (:tan, :Tan), (:cosh, :Cosh), (:sinh, :Sinh), (:tanh, :Tanh), (:log10, :Log10)]
+                      (:tan, :Tan), (:cosh, :Cosh), (:sinh, :Sinh), (:tanh, :Tanh),
+                      (:log10, :Log10)]
         f! = Symbol("$(f)!")
         name = string(f)
         addfunction(functions, (f, (T,)), "Vectorize.VML.$f")
@@ -215,7 +218,11 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d")]
                       (:erfc, :Erfc), (:cdfnorm, :CdfNorm),  (:erfinv, :ErfInv),
                       (:erfcinv,  :ErfcInv),  (:cdfnorminv, :CdfNormInv), (:lgamma, :LGamma),
                       (:gamma, :TGamma), (:floor, :Floor), (:trunc, :Trunc),
-                      (:round, :Round), (:frac,  :Frac), (:abs, :Abs), (:sqr, :Sqr)]
+                      (:round, :Round), (:frac,  :Frac), (:abs, :Abs), (:sqr, :Sqr),
+                      (:cosd, :Cosd), (:sind, :Sind), (:tand, :Tand),
+                      (:log2, :Log2), (:log1p, :Log1p),
+                      (:expm1, :Expm1), (:exp2, :Exp2), (:exp10, :Exp10),
+                      (:cospi, :Cospi), (:sinpi, :Sinpi)]
         f! = Symbol("$(f)!")
         name = string(f)
         addfunction(functions, (f, (T,)), "Vectorize.VML.$f")

--- a/src/VML.jl
+++ b/src/VML.jl
@@ -47,11 +47,11 @@ const VML_FTZDAZ_OFF       =  0x00140000     # accurate denormal value processin
 
 
 """
-This function sets the default values for the VME library on import, 
-allowing for the precompilation of the rest of the package. 
+This function sets the default values for the VME library on import,
+allowing for the precompilation of the rest of the package.
 """
 function __init__()
-    
+
     # Open librt
     Libdl.dlopen(librt)
 
@@ -62,7 +62,7 @@ end
 
 """
 Sets accuracy, error, and FTZDAZ modes for all VML functions. This is automatically
-called in init() but can also be called to change the modes during runtime. 
+called in init() but can also be called to change the modes during runtime.
 """
 function setmode(mode)
     oldmode = ccall(("vmlSetMode", librt),  Cuint,
@@ -73,7 +73,7 @@ end
 
 """
 Returns the accuracy, error, and FTZDAZ modes for all VML functions". This is automatically
-called in init() but can also be called to change the modes during runtime". 
+called in init() but can also be called to change the modes during runtime".
 """
 function getmode()
     status = ccall(("vmlGetMode", librt),  Cuint,
@@ -94,7 +94,7 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
             `$($f)(X::Array{$($T)}, Y::Array{$($T)})`
             Implements element-wise **$($name)** over two **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T}, Y::Array{$T})
                 out = similar(X)
                 return $(f!)(out, X, Y)
@@ -103,9 +103,9 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
             `$($f!)(result::Array{$($T)}, X::Array{$($T)}, Y::Array{$($T)})`
             Implements element-wise **$($name)** over two **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T},  Ptr{$T}),
                       length(out), X, Y,  out)
                 return out
@@ -125,7 +125,7 @@ for (T, prefix) in [(Float32, "s"),  (Float64, "d")]
             `$($f)(X::Array{$($T)}, Y::Array{$($T)})`
             Implements element-wise **$($name)** over two **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T}, Y::Array{$T})
                 out = similar(X)
                 return $(f!)(out, X, Y)
@@ -134,9 +134,9 @@ for (T, prefix) in [(Float32, "s"),  (Float64, "d")]
             `$($f!)(result::Array{$($T)}, X::Array{$($T)}, Y::Array{$($T)})`
             Implements element-wise **$($name)** over two **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T},  Ptr{$T}),
                       length(out), X, Y,  out)
                 return out
@@ -156,7 +156,7 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             `$($f)(X::Array{$($T)}, Y::Array{$($T)})`
             Implements element-wise **$($name)** over two **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T}, Y::Array{$T})
                 out = similar(X)
                 return $(f!)(out, X, Y)
@@ -165,9 +165,9 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             `$($f!)(result::Array{$($T)}, X::Array{$($T)}, Y::Array{$($T)})`
             Implements element-wise **$($name)** over two **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T}, Y::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T},  Ptr{$T}),
                       length(out), X, Y,  out)
                 return out
@@ -191,7 +191,7 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
             `$($f)(X::Array{$($T)})`
             Implements element-wise **$($name)** over a **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 out = similar(X)
                 return $(f!)(out, X)
@@ -200,9 +200,9 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
             `$($f!)(result::Array{$($T)}, X::Array{$($T)})`
             Implements element-wise **$($name)** over a **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T}),
                       length(out), X, out)
                 return out
@@ -215,7 +215,7 @@ end
 for (T, prefix) in [(Float32,  "s"), (Float64, "d")]
     for (f, fvml) in [(:inv, :Inv), (:invsqrt, :InvSqrt),  (:cbrt,  :Cbrt),
                       (:invcbrt, :InvCbrt), (:pow2o3, :Pow2o3), (:pow3o2, :Pow3o2),
-                      (:erf, :Erf),  (:ceil, :Ceil), 
+                      (:erf, :Erf),  (:ceil, :Ceil),
                       (:erfc, :Erfc), (:cdfnorm, :CdfNorm),  (:erfinv, :ErfInv),
                       (:erfcinv,  :ErfcInv),  (:cdfnorminv, :CdfNormInv), (:lgamma, :LGamma),
                       (:gamma, :TGamma), (:floor, :Floor), (:trunc, :Trunc),
@@ -229,7 +229,7 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d")]
             `$($f)(X::Array{$($T)})`
             Implements element-wise **$($name)** over a **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 out = similar(X)
                 return $(f!)(out, X)
@@ -238,9 +238,9 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d")]
             `$($f!)(result::Array{$($T)}, X::Array{$($T)})`
             Implements element-wise **$($name)** over a **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T}),
                       length(out), X, out)
                 return out
@@ -260,7 +260,7 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             `$($f)(X::Array{$($T)})`
             Implements element-wise **$($name)** over a **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 out = similar(X)
                 return $(f!)(out, X)
@@ -269,9 +269,9 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             `$($f!)(result::Array{$($T)}, X::Array{$($T)})`
             Implements element-wise **$($name)** over a **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{$T}, X::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{$T}),
                       length(out), X, out)
                 return out
@@ -292,7 +292,7 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             `$($f)(X::Array{$($T)})`
             Calculates the **$($name)** element-wise over a **Array{$($T)}**. Allocates
             memory to store result. *Returns:* **Array{$($T)}**
-            """ ->
+            """
             function ($f)(X::Array{$T})
                 out = Array(real($T), length(X))
                 return $(f!)(out, X)
@@ -301,9 +301,9 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             `$($f!)(result::Array{$($T)}, X::Array{$($T)})`
             Calculates the **$($name)** element-wise over a **Array{$($T)}** and overwrites
             the result vector with computed value. *Returns:* **Array{$($T)}** `result`
-            """ ->
+            """
             function ($f!)(out::Array{real($T)}, X::Array{$T})
-                ccall($(string("v", prefix, fvml), librt),  Void,
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
                       (Cint, Ptr{$T}, Ptr{real($T)}),
                       length(out), X, out)
                 return out

--- a/src/VML.jl
+++ b/src/VML.jl
@@ -83,8 +83,8 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
     for (f, fvml, name) in [(:add, :Add, "addition"), (:mul, :Mul, "multiplcation"),
                       (:sub, :Sub, "subtraction"), (:div, :Div, "division"), (:pow, :Pow, "power")]
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)}, Y::Array{$($T)})`
@@ -115,8 +115,8 @@ for (T, prefix) in [(Float32, "s"),  (Float64, "d")]
     for (f, fvml, name) in [(:hypot, :Hypot, "hypotenuse"), (:atan, :Atan2, "atan2"),
                             (:max, :Fmax, "max"), (:min, :Fmin, "min")]
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)}, Y::Array{$($T)})`
@@ -147,8 +147,8 @@ end
 for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
     for (f, fvml, name) in [(:dot, :MulByConj, "multiply-by-conjugate")]
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,T)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (T,T,T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T}, Array{T})), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)}, Y::Array{$($T)})`
@@ -183,8 +183,8 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  
                       (:log10, :Log10)]
         f! = Symbol("$(f)!")
         name = string(f)
-        addfunction(functions, (f, (T,)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (T,T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)})`
@@ -225,8 +225,8 @@ for (T, prefix) in [(Float32,  "s"), (Float64, "d")]
                       (:cospi, :Cospi), (:sinpi, :Sinpi)]
         f! = Symbol("$(f)!")
         name = string(f)
-        addfunction(functions, (f, (T,)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (T,T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)})`
@@ -256,8 +256,8 @@ end
 for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
     for (f, fvml, name) in [(:conj,  :Conj, "conjugation")]
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (T,T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
              @doc """
             `$($f)(X::Array{$($T)})`
@@ -288,8 +288,8 @@ end
 for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
     for (f, fvml, name) in [(:abs, :Abs, "absolute-value"),  (:angle,  :Arg, "complex-argument") ]
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (real(T),T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{real(T)},Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)})`
@@ -320,8 +320,8 @@ end
 for (T, prefix) in [(Float32, "c"),  (Float64, "z")]
     for (f, fvml, name) in [(:cis, :CIS, "cosine-imaginary-sin"),]
         f! = Symbol("$(f)!")
-        addfunction(functions, (f, (T,)), "Vectorize.VML.$f")
-        addfunction(functions, (f!, (complex(T),T)), "Vectorize.VML.$(f!)")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{complex(T)},Array{T})), "Vectorize.VML.$(f!)")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)})`
@@ -346,5 +346,37 @@ for (T, prefix) in [(Float32, "c"),  (Float64, "z")]
         end
     end
 end
+
+# Basic operations on two args, with one arg being scalar
+for (T, prefix) in [(Float32,  "s"), (Float64, "d"),  (Complex{Float32}, "c"),  (Complex{Float64}, "z")]
+    for (f, fvml, name) in ((:pow, :Powx, "scalar power"),)
+        f! = Symbol("$(f)!")
+        addfunction(functions, (f, (Array{T}, T)), "Vectorize.VML.$f")
+        addfunction(functions, (f!, (Array{T}, Array{T}, T)), "Vectorize.VML.$(f!)")
+        @eval begin
+            @doc """
+            `$($f)(X::Array{$($T)}, Y::$($T))`
+            Implements element-wise **$($name)** over two **Array{$($T)}**. Allocates
+            memory to store result. *Returns:* **Array{$($T)}**
+            """
+            function ($f)(X::Array{$T}, Y::$T)
+                out = similar(X)
+                return $(f!)(out, X, Y)
+            end
+            @doc """
+            `$($f!)(result::Array{$($T)}, X::Array{$($T)}, Y::$($T))`
+            Implements element-wise **$($name)** over two **Array{$($T)}** and overwrites
+            the result vector with computed value. *Returns:* **Array{$($T)}** `result`
+            """
+            function ($f!)(out::Array{$T}, X::Array{$T}, Y::$T)
+                ccall($(string("v", prefix, fvml), librt),  Cvoid,
+                      (Cint, Ptr{$T}, $T, Ptr{$T}),
+                      length(out), X, Y, out)
+                return out
+            end
+        end
+    end
+end
+
 
 end # End Module

--- a/src/VML.jl
+++ b/src/VML.jl
@@ -11,13 +11,9 @@
 module VML
 import Vectorize: functions, addfunction
 
-# Cross-version compatibility
-if VERSION < v"0.5.0-dev" # Julia v0.4
-    readstring(cmd) = readall(cmd)
-    OS = OS_NAME
-else
-    OS = Sys.KERNEL
-end
+using Libdl
+
+OS = Sys.KERNEL
 
 # Library dependency for VML
 const global librt = Libdl.find_library(["libmkl_rt"], ["/opt/intel/mkl/lib"])
@@ -116,7 +112,7 @@ end
 
 # Real only returning real - two args
 for (T, prefix) in [(Float32, "s"),  (Float64, "d")]
-    for (f, fvml, name) in [(:hypot, :Hypot, "hypotenuse"), (:atan2, :Atan2, "atan2")]
+    for (f, fvml, name) in [(:hypot, :Hypot, "hypotenuse"), (:atan, :Atan2, "atan2")]
         f! = Symbol("$(f)!")
         addfunction(functions, (f, (T,T)), "Vectorize.VML.$f")
         addfunction(functions, (f!, (T,T,T)), "Vectorize.VML.$(f!)")
@@ -294,7 +290,7 @@ for (T, prefix) in [(Complex{Float32}, "c"),  (Complex{Float64}, "z")]
             memory to store result. *Returns:* **Array{$($T)}**
             """
             function ($f)(X::Array{$T})
-                out = Array(real($T), length(X))
+                out = Array{real($T)}(undef, length(X))
                 return $(f!)(out, X)
             end
             @doc """

--- a/src/Vectorize.jl
+++ b/src/Vectorize.jl
@@ -1,4 +1,3 @@
-__precompile__()
 ##===----------------------------------------------------------------------===##
 ##                                   ACCELERATE.JL                            ##
 ##                                                                            ##
@@ -11,14 +10,10 @@ __precompile__()
 ##===----------------------------------------------------------------------===##
 module Vectorize
 
+using Libdl
 export @vectorize
 
-# Cross-version compatibility
-if VERSION < v"0.5.0-dev" # Julia v0.4
-    OS = OS_NAME
-else
-    OS = Sys.KERNEL
-end
+OS = Sys.KERNEL
 
 ## FUNCTION DICTIONARY
 functions = Dict()
@@ -51,12 +46,12 @@ if libyeppp_ != ""
     @eval const global libyeppp = libyeppp_
 else
     currdir = @__FILE__
-    @static if is_windows()
+    @static if Sys.iswindows()
         bindir = currdir[1:end-16]*"deps\\src\\yeppp\\binaries\\"
     else
         bindir = currdir[1:end-16]*"deps/src/yeppp/binaries/"
     end
-    
+
     if OS == :Darwin
         @eval const global libyeppp = bindir*"macosx/x86_64/libyeppp.dylib"
     elseif OS == :Linux

--- a/src/Vectorize.jl
+++ b/src/Vectorize.jl
@@ -164,10 +164,12 @@ end
 function makeargs(Targs)
     arg_str = "Tuple{"
     for T in Targs
-        arg_str *= "Array{$T, N}, "
+        arg_str *= "$T, "
     end
     arg_str = arg_str[1:end-2]
     arg_str *= "}"
+    arg_str = replace(arg_str, " where N" => "")
+
     return Meta.parse(arg_str)
 end
 

--- a/src/Vectorize.jl
+++ b/src/Vectorize.jl
@@ -109,7 +109,7 @@ macro replacebase(fs...)
                     Tdest = first(args)
                     Targs = makeargs(args[2:end])
                     e = quote
-                        (Base.copyto!)(dest::Array{$Tdest, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($m.$f), $Targs}) where {Style, Axes, N} = (Vectorize.$fvec)(dest, bc.args...)
+                        (Base.copyto!)(dest::$Tdest, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($m.$f), $Targs}) where {Style, Axes, N} = (Vectorize.$fvec)(dest, bc.args...)
                     end
                 else
                     Targs = makeargs(args)
@@ -127,7 +127,7 @@ end
 function get_corresponding_f(fvec)
     fstr = string(fvec)
     if ismutating(fvec)
-        fstr = fstr[1:end-1]
+        fstr = chop(fstr)
     end
     if fstr == "add"
         fstr = "+"

--- a/src/Vectorize.jl
+++ b/src/Vectorize.jl
@@ -11,7 +11,9 @@
 module Vectorize
 
 using Libdl
-export @vectorize
+using SpecialFunctions
+using Statistics
+export @vectorize, @replacebase
 
 OS = Sys.KERNEL
 
@@ -90,6 +92,78 @@ macro vectorize(ex)
         arg3 = ex.args[4]
         return esc(:($f($arg1, $arg2, $arg3)))
     end
+end
+
+# replacebase macro
+"""
+Replace all broadcasted base functions with benchmarked vectorized equivalents.
+"""
+macro replacebase()
+    b = Expr(:block)
+    for ((fvec, args), vectorized_f) in functions
+        m, f = get_corresponding_f(fvec)
+        if m == :Base
+            if ismutating(fvec)
+                Tdest = first(args)
+                Targs = makeargs(args[2:end])
+                e = quote
+                    (Base.copyto!)(dest::Array{$Tdest, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($m.$f), $Targs}) where {Style, Axes, N} = (Vectorize.$fvec)(dest, bc.args...)
+                end
+            else
+                Targs = makeargs(args)
+                e = quote
+                    (Base.copy)(bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($m.$f), $Targs}) where {Style, Axes, N} = (Vectorize.$fvec)(bc.args...)
+                end
+            end
+            push!(b.args, e)
+        end
+    end
+    b
+end
+
+function get_corresponding_f(fvec)
+    fstr = string(fvec)
+    if ismutating(fvec)
+        fstr = fstr[1:end-1]
+    end
+    if fstr == "add"
+        fstr = "+"
+    elseif fstr == "sub"
+        fstr = "-"
+    elseif fstr == "mul"
+        fstr = "*"
+    elseif fstr == "div"
+        fstr = "/"
+    elseif fstr == "rec"
+        fstr = "inv"
+    elseif fstr == "pow"
+        fstr = "^"
+    end
+
+    m = :Base
+    if fstr in ("cdfnorminv", "erf", "erfc", "erfi", "erfinv", "erfcinv", "cdfnorm")
+        m = :SpecialFunctions
+    elseif fstr in ("invcbrt", )
+        m = :DSP
+    elseif fstr in ("mean", )
+        m = :Statistics
+    elseif fstr in ("pow3o2", "frac", "mulbyconj", "tanpi", "fdiv", "invsqrt",
+                    "sqr", "pow2o3", "summag", "sumsqr", )
+        m = :None
+    end
+
+    fsym = Meta.parse(fstr)
+    return m, fsym
+end
+@inline ismutating(f) = last(string(f)) == '!'
+function makeargs(Targs)
+    arg_str = "Tuple{"
+    for T in Targs
+        arg_str *= "Array{$T, N}, "
+    end
+    arg_str = arg_str[1:end-2]
+    arg_str *= "}"
+    return Meta.parse(arg_str)
 end
 
 # Include optimized functions

--- a/src/Vectorize.jl
+++ b/src/Vectorize.jl
@@ -150,6 +150,8 @@ function get_corresponding_f(fvec)
         m = :DSP
     elseif fstr in ("mean", )
         m = :Statistics
+    elseif fstr in ("dot", )
+        m = :LinearAlgebra
     elseif fstr in ("pow3o2", "frac", "mulbyconj", "tanpi", "fdiv", "invsqrt",
                     "sqr", "pow2o3", "summag", "sumsqr", )
         m = :None

--- a/src/Vectorize.jl
+++ b/src/Vectorize.jl
@@ -146,14 +146,12 @@ function get_corresponding_f(fvec)
     m = :Base
     if fstr in ("cdfnorminv", "erf", "erfc", "erfi", "erfinv", "erfcinv", "cdfnorm")
         m = :SpecialFunctions
-    elseif fstr in ("invcbrt", )
-        m = :DSP
     elseif fstr in ("mean", )
         m = :Statistics
     elseif fstr in ("dot", )
         m = :LinearAlgebra
     elseif fstr in ("pow3o2", "frac", "mulbyconj", "tanpi", "fdiv", "invsqrt",
-                    "sqr", "pow2o3", "summag", "sumsqr", )
+                    "sqr", "pow2o3", "summag", "sumsqr", "invcbrt")
         m = :None
     end
 

--- a/src/Yeppp.jl
+++ b/src/Yeppp.jl
@@ -72,7 +72,7 @@ for (f, fname, name) in ((:add, "Add", "addition"),  (:sub, "Subtract", "subtrac
         # generate Yeppp function name
         yepppname = string("yepCore_$(fname)_", identifier[argtype1], identifier[argtype2],
                            "_", identifier[returntype])
-        addfunction(functions, (f, (Float64,Float64)), "Vectorize.Yeppp.$f")
+        addfunction(functions, (f, (Array{Float64}, Array{Float64})), "Vectorize.Yeppp.$f")
         @eval begin
             @doc """
             `$($f)(X::Array{$($argtype1)}, Y::Array{$($argtype2)})`
@@ -97,8 +97,8 @@ for (f, fname) in [(:sin, "Sin"),  (:cos, "Cos"),  (:tan, "Tan"), (:log, "Log"),
     name = string(f)
     f! = Symbol("$(f)!")
     # register functions for build
-    addfunction(functions, (f, (Float64,)), "Vectorize.Yeppp.$f")
-    addfunction(functions, (f!, (Float64,Float64)), "Vectorize.Yeppp.$(f!)")
+    addfunction(functions, (f, (Array{Float64},)), "Vectorize.Yeppp.$f")
+    addfunction(functions, (f!, (Array{Float64}, Array{Float64})), "Vectorize.Yeppp.$(f!)")
     @eval begin
          @doc """
         `$($f)(X::Array{Float64})`
@@ -128,7 +128,7 @@ end
 for (T, Tscalar) in ((Float32, "S32f"), (Float64, "S64f"))
     for (f, fname, name) in [(:sum, "Sum", "sum"), (:sumsqr, "SumSquares", "sum-of-squares")]
         yepppname = string("yepCore_$(fname)_", identifier[T], "_", Tscalar)
-        addfunction(functions, (f, (T,)), "Vectorize.Yeppp.$f")
+        addfunction(functions, (f, (Array{T},)), "Vectorize.Yeppp.$f")
         @eval begin
             @doc """
             `$($f)(X::Array{$($T)})`

--- a/test/AccelerateTests.jl
+++ b/test/AccelerateTests.jl
@@ -1,28 +1,18 @@
-using Vectorize
-
-## Use correct version of Base.Test
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
-
 ## Initialize testing globals
 println("===== Testing Accelerate =====")
 N = 1000
-srand(13)
+Random.seed!(13)
 
 
 
 ## LOGARITHM
 for T in (Float32, Float64)
     @testset "Accelerate: Logarithmic::$T" begin
-        X::Array{T} = exp(10*randn(N))
+        X = exp.(10*randn(T, N))
         @testset "Testing $f::$T" for f in [:log,:log2,:log10, :log1p]
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
     end
 end
@@ -31,36 +21,36 @@ end
 for T in (Float32, Float64)
     @testset "Accelerate: Exponential::$T" begin
         @testset "Testing $f::$T" for f in [:exp,:exp2,:expm1]
-            X::Array{T} = 10*randn(N)
+            X = 10*randn(T, N)
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
     end
 end
 
 ## TRIGONOMETRIC
 for T in (Float32, Float64)
-    X::Array{T} = 10*randn(N)
+    X = 10*randn(T, N)
     @testset "Accelerate: Trigonometric::$T" begin
         @testset "Testing $f::$T" for f in [:sin,:sinpi,:cos,:cospi,:tan,:atan] # tanpi not defined in Base
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
 
-        Y::Array{T} = 10*randn(N)
-        @testset "Testing $f::$T" for f in [:atan2]
+        Y = 10*randn(T, N)
+        @testset "Testing $f::$T" for f in [:atan]
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(X,Y) ≈ fb(X,Y)
+            @test fa(X,Y) ≈ fb.(X,Y)
         end
 
-        Z::Array{T} = 2*rand(N)-1
+        Z = 2*rand(T, N).-1
         @testset "Testing $f::$T" for f in [:asin,:acos]
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(Z) ≈ fb(Z)
+            @test fa(Z) ≈ fb.(Z)
         end
     end
 end
@@ -68,25 +58,25 @@ end
 ## HYPERBOLIC
 for T in (Float32, Float64)
     @testset "Accelerate: Hyperbolic::$T" begin
-        X = 10*randn(N)
+        X = 10*randn(T, N)
         @testset "Testing $f::$T" for f in [:sinh,:cosh,:tanh,:asinh]
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(X) ≈ fb(X)
+            @test fa(X) ≈ fb.(X)
         end
 
-        Y = exp(10*randn(N))+1
+        Y = exp.(10*randn(T, N)).+1
         @testset "Testing $f::$T" for f in [:acosh]
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(Y) ≈ fb(Y)
+            @test fa(Y) ≈ fb.(Y)
         end
 
-        Z = 2*rand(N)-1
+        Z = 2*rand(T, N).-1
         @testset "Testing $f::$T" for f in [:atanh]
             @eval fb = $f
             @eval fa = Vectorize.Accelerate.$f
-            @test fa(Z) ≈ fb(Z)
+            @test fa(Z) ≈ fb.(Z)
         end
     end
 end
@@ -94,12 +84,12 @@ end
 ## VECTOR OPERATIONS
 for T in (Float32, Float64)
     @testset "Accelerate: Vector Operations::$T" begin
-        X = 10*randn(N)
-        Y = 10*randn(N)
-        @testset "Testing $fa::$T" for (f, fa) in [(:+, :add), (:-, :sub), (:.*, :mul), (:./, :div)]
+        X = 10*randn(T, N)
+        Y = 10*randn(T, N)
+        @testset "Testing $facc::$T" for (f, facc) in [(:+, :add), (:-, :sub), (:*, :mul), (:/, :div)]
             @eval fb = $f
-            @eval facc = Vectorize.Accelerate.$fa
-            @test fb(X, Y) ≈ facc(X, Y)
+            @eval facl = Vectorize.Accelerate.$facc
+            @test fb.(X, Y) ≈ facl(X, Y)
         end
     end
 end

--- a/test/VMLTests.jl
+++ b/test/VMLTests.jl
@@ -47,6 +47,19 @@ for T in [Complex{Float32}, Complex{Float64}]
     end
 end
 
+# Scalar Power
+for T in [Float32, Float64, Complex{Float32}, Complex{Float64}]
+    @testset "VML: Complex Arithmetic::$T" begin
+        X = rand(T, N)
+        a = rand(T)
+        @testset "Testing $f::$T" for (f, fbs) in ((:pow, ^),)
+            @eval fbase = $fbs
+            @eval fvml = Vectorize.VML.$f
+            @test fbase.(X, a) ≈ fvml(X, a)
+        end
+    end
+end
+
 # Real Vector Math
 for T in [Float32, Float64]
     @testset "VML: Real Vector Math::$T" begin

--- a/test/VMLTests.jl
+++ b/test/VMLTests.jl
@@ -19,7 +19,8 @@ for T in [Float32, Float64]
         X = convert(Vector{T}, abs.(randn(N)))
         Y = convert(Vector{T}, abs.(randn(N)))
         @testset "Testing $f::$T" for (f, fbs) in [(:add, +), (:sub, -), (:div, /), (:mul, *),
-                                                  (:hypot, :hypot), (:atan, :atan), (:pow, ^)]
+                                                  (:hypot, :hypot), (:atan, :atan), (:pow, ^),
+                                                  (:max, :max), (:min, :min)]
             @eval fbase = $fbs
             @eval fvml = Vectorize.VML.$f
             @test fbase.(X, Y) ≈ fvml(X, Y)
@@ -39,9 +40,9 @@ for T in [Complex{Float32}, Complex{Float64}]
             @test fbase.(X, Y) ≈ fvml(X, Y)
         end
 
-        @testset "Testing $f::$T" for f in [:mulbyconj]
+        @testset "Testing $f::$T" for f in [:dot]
             @eval fvml = Vectorize.VML.$f
-            @test X .* conj.(Y) ≈ fvml(X, Y)
+            @test dot.(X, Y) ≈ fvml(X, Y)
         end
     end
 end
@@ -55,13 +56,16 @@ for T in [Float32, Float64]
         W = clamp.(convert(Vector{T}, randn(N)), 0,  2) # [0, 2]
         @testset "Testing $f::$T" for f in [:exp, :abs, :ceil, :floor, :round,
                                             :trunc, :cos, :sin, :tan, :cosh, :sinh, :tanh,
-                                            :cbrt, :erf, :erfc, :lgamma, :gamma]
+                                            :cbrt, :erf, :erfc, :lgamma, :gamma,
+                                            :sinpi, :cospi, :sind, :cosd, :tand,
+                                            :exp2, :exp10, :expm1, :cis]
             @eval fb = $f
             @eval fvml = Vectorize.VML.$f
             @test fb.(X) ≈ fvml(X)
         end
 
-        @testset "Testing $f::$T" for f in [:sqrt, :log10, :acosh, :asinh, :log]
+        @testset "Testing $f::$T" for f in [:sqrt, :log10, :acosh, :asinh, :log,
+                                            :log2, :log1p]
             @eval fb = $f
             @eval fvml = Vectorize.VML.$f
             @test fb.(Y) ≈ fvml(Y)

--- a/test/VectorizeTests.jl
+++ b/test/VectorizeTests.jl
@@ -3,6 +3,39 @@ println("===== Testing Vectorize Benchmarked Functions =====")
 N = 1000
 Random.seed!(13)
 
+for T in (Float32, Float64)
+    @testset "@replacebase macro::$T" begin
+
+        @replacebase cis
+        @replacebase atan
+        @replacebase ^
+
+        X = rand(T, N)
+        Y = rand(T, N)
+        invcbrt = convert(T, -1/3)
+
+        @test Vectorize.cis(X) == cis.(X)
+        @test Vectorize.atan(X) == atan.(X)
+        @test Vectorize.atan(X, Y) == atan.(X, Y)
+        @test Vectorize.pow(X, Y) == X.^Y
+        @test Vectorize.pow(X, invcbrt) == X.^(invcbrt)
+
+        #test in-place
+        Zvec = similar(complex(X))
+        Zbc = similar(Zvec)
+        Vectorize.cis!(Zvec, X)
+        Zbc .= cis.(X)
+        @test Zbc == Zvec
+        Yvec = similar(X)
+        Ybc = similar(Yvec)
+        Vectorize.atan!(Yvec, X)
+        Ybc .= atan.(X)
+        @test Yvec == Ybc
+        Vectorize.pow!(Yvec, X, invcbrt)
+        Ybc .= X.^(invcbrt)
+        @test Yvec == Ybc
+    end
+end
 # Real Arithmetic
 # for T in [Float32, Float64]
 #     @testset "Vectorize: Basic Arithmetic::$T" begin

--- a/test/VectorizeTests.jl
+++ b/test/VectorizeTests.jl
@@ -1,16 +1,7 @@
-using Vectorize
-
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
-
 println("===== Testing Vectorize Benchmarked Functions =====")
 # Length of test array
 N = 1000
-srand(13)
+Random.seed!(13)
 
 # Real Arithmetic
 # for T in [Float32, Float64]
@@ -27,9 +18,9 @@ srand(13)
 #                 if !(isa(err, UndefVarError))
 #                     error("Testing $(fvec) has failed")
 #                 end
-                
+
 #             end
-         
+
 #             @test fbase(X, Y) ≈ fvec(X, Y)
 #             println("Testing $f")
 #         end
@@ -57,7 +48,7 @@ srand(13)
 #         end
 
 #         @testset "Testing $f::$T" for f in [:mulbyconj]
-            
+
 #             try # need to catch functions that aren't available from any framework
 #                 @eval fvec = Vectorize.$f
 #             catch err
@@ -103,7 +94,7 @@ srand(13)
 #         #     @eval fvec = Vectorize.$f
 #         #     @test fb(W) ≈ fvec(W)
 #         # end
-        
+
 #         @testset "Testing $f::$T" for f in [:acos, :asin, :atan]#, :atanh] #, :erfinv]
 #             @eval fb = $f
 #             @eval fvec = Vectorize.$f

--- a/test/YepppTests.jl
+++ b/test/YepppTests.jl
@@ -1,27 +1,18 @@
-using Vectorize
-
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
-
 println("===== Testing Yeppp!  =====")
 
 ## length of test array
 N = 1000
-srand(7)
+Random.seed!(7)
 
 ## YepCore Signed Integer Tests
 for T in (Int8, Int16, Int32, Int64)
     @testset "Yeppp: Integer Operations::$T" begin
-        X = round(T, randn(N))
-        Y = round(T, randn(N))
-        @testset "Testing $fy::$T" for (f, fy) in [(.+, :add), (.-, :sub), (.*, :mul)]
+        X = round.(T, randn(N))
+        Y = round.(T, randn(N))
+        @testset "Testing $fy::$T" for (f, fy) in [(+, :add), (-, :sub), (*, :mul)]
             @eval fb = $f
             @eval fyp = Vectorize.Yeppp.$fy
-            @test fb(X, Y) ≈ fyp(X, Y)
+            @test fb.(X, Y) ≈ fyp(X, Y)
         end
     end
 end
@@ -29,12 +20,12 @@ end
 ## YepCore Floating Point Tests
 for T in (Float32, Float64)
     @testset "Yeppp: Floating Point Operations::$T" begin
-        X = randn(N)
-        Y = randn(N)
-        @testset "Testing $fy::$T" for (f, fy) in [(.+, :add), (.-, :sub), (.*, :mul)]
+        X = randn(T, N)
+        Y = randn(T, N)
+        @testset "Testing $fy::$T" for (f, fy) in [(+, :add), (-, :sub), (*, :mul)]
             @eval fb = $f
             @eval fyp = Vectorize.Yeppp.$fy
-            @test fb(X, Y) ≈ fyp(X, Y)
+            @test fb.(X, Y) ≈ fyp(X, Y)
         end
     end
 end
@@ -42,12 +33,12 @@ end
 # YeppCore Max/Min Integer
 for T in (Int8, Int16, Int32)
     @testset "Yeppp: Integer Max/Min::$T" begin
-        X = round(T, randn(N))
-        Y = round(T, randn(N))
+        X = round.(T, randn(N))
+        Y = round.(T, randn(N))
         @testset "Testing $fy::$T" for (f, fy) in [(max, :max), (min, :min)]
             @eval fb = $f
             @eval fyp = Vectorize.Yeppp.$fy
-            @test fb(X, Y) ≈ fyp(X, Y)
+            @test fb.(X, Y) ≈ fyp(X, Y)
         end
     end
 end
@@ -55,12 +46,12 @@ end
 # YeppCore Max/Min Floating Point
 for T in (Float32, Float64)
     @testset "Yeppp: Floating Point Max/Min::$T" begin
-        X = randn(N)
-        Y = randn(N)
+        X = randn(T, N)
+        Y = randn(T, N)
         @testset "Testing $fy::$T" for (f, fy) in [(max, :max), (min, :min)]
             @eval fb = $f
             @eval fyp = Vectorize.Yeppp.$fy
-            @test fb(X, Y) ≈ fyp(X, Y)
+            @test fb.(X, Y) ≈ fyp(X, Y)
         end
     end
 end
@@ -88,14 +79,14 @@ for T in [Float64]
         @testset "Testing $f::$T" for f in [:sin, :cos, :tan]
             @eval fb = $f
             @eval fy = Vectorize.Yeppp.$f
-            @test fb(X) ≈ fy(X)
+            @test fb.(X) ≈ fy(X)
         end
 
         @testset "Testing $f::$T" for f in [:log, :exp]
             @eval fb = $f
             @eval fy = Vectorize.Yeppp.$f
-            @test fb(abs(X)) ≈ fy(abs(X))
-            
+            @test fb.(abs.(X)) ≈ fy(abs.(X))
+
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,10 @@
 using Vectorize
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Test
+using Random
+using Libdl
 
 ## Test Apple Accelerate
-@static if is_apple()
+@static if Sys.isapple()
     include("AccelerateTests.jl")
 else
     println("Accelerate not present. Aborting Accelerate tests")
@@ -23,4 +20,3 @@ end
 
 ## Running tests over benchmarked Vectorized functions
 include("VectorizeTests.jl")
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using Random
 using Libdl
 using SpecialFunctions
+using LinearAlgebra
 
 ## Test Apple Accelerate
 @static if Sys.isapple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Vectorize
 using Test
 using Random
 using Libdl
+using SpecialFunctions
 
 ## Test Apple Accelerate
 @static if Sys.isapple()


### PR DESCRIPTION
Based off #18, this introduces a new macro `@replacebase` which overloads broadcast calls to use the benchmarked `Vectorize` functions. I've updated the documentation and tests.

As an example on my machine:
```
julia> using BenchmarkTools

julia> a = rand(1000); b = similar(a);

julia> @btime $b .= $a.^(-1/3)
  19.044 μs (0 allocations: 0 bytes)

julia> using Vectorize

julia> @replacebase ^

julia> @btime $b .= $a.^(-1/3);
  2.209 μs (0 allocations: 0 bytes)
```

I've also added a bunch of new VML functions.